### PR TITLE
New summary images, color videos, smarter downscaling

### DIFF
--- a/src/aind_ophys_utils/array_utils.py
+++ b/src/aind_ophys_utils/array_utils.py
@@ -109,21 +109,8 @@ def downsample_array(
         "first": lambda arr, idx: arr[idx[0]],
         "last": lambda arr, idx: arr[idx[-1]],
     }
-    # if dtype is None and array.dtype.itemsize < 4:
-    #     sampling_strategies["mean"] = \
-    #         lambda arr, idx: arr[idx].mean(axis=0).astype(np.float32)
-    #     sampling_strategies["median"] = \
-    #         lambda arr, idx: np.median(arr[idx], axis=0).astype(np.float32)
-    # if dtype is not None:
-    #     sampling_strategies["mean"] = \
-    #         lambda arr, idx: arr[idx].mean(axis=0).astype(dtype)
-    #     sampling_strategies["median"] = \
-    #         lambda arr, idx: np.median(arr[idx], axis=0).astype(dtype)
-
-    mean_dtype = None
-    if dtype is not None:
-        mean_dtype = dtype
-    elif array.dtype.itemsize < 4:
+    mean_dtype = dtype
+    if dtype is None and array.dtype.itemsize < 4:
         mean_dtype = np.float32
     if mean_dtype is not None:
         sampling_strategies["mean"] = \

--- a/src/aind_ophys_utils/video_utils.py
+++ b/src/aind_ophys_utils/video_utils.py
@@ -53,6 +53,7 @@ def encode_video(
     bitrate: str = "0",
     crf: int = 20,
     cpu_used: int = 4,
+    color: bool = False,
 ) -> str:
     """Encode a video with vp9 codec via imageio-ffmpeg
 
@@ -76,6 +77,8 @@ def encode_video(
         Sets how efficient the compression will be, by default 4. Values can
         be between 0 and 5. Higher values increase encoding speed at the
         expense of having some impact on quality and rate control accuracy.
+    color : bool, optional
+        Whether the input video is color or grayscale, by default False
 
     Returns
     -------
@@ -89,7 +92,7 @@ def encode_video(
     writer = mpg.write_frames(
         output_path,
         video_shape,
-        pix_fmt_in="gray8",
+        pix_fmt_in="rgb24" if color else "gray8",
         pix_fmt_out="yuv420p",
         codec="libvpx-vp9",
         fps=fps,

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -25,7 +25,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
 
 
 @pytest.mark.parametrize(
-    ("array, input_fps, output_fps, random_seed, strategy, expected"),
+    ("array, input_fps, output_fps, random_seed, strategy, dtype, expected"),
     [
         (
             # random downsample 1D array
@@ -34,6 +34,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "random",
+            None,
             np.array([2, 5]),
         ),
         (
@@ -45,6 +46,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "random",
+            None,
             np.array([[2, 1], [5, 8]]),
         ),
         (
@@ -54,6 +56,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "first",
+            None,
             np.array([1, 3]),
         ),
         (
@@ -65,6 +68,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "first",
+            None,
             np.array([[1, 3], [3, 2]]),
         ),
         (
@@ -74,6 +78,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "last",
+            None,
             np.array([2, 11]),
         ),
         (
@@ -85,6 +90,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "last",
+            None,
             np.array([[2, 1], [11, 12]]),
         ),
         (
@@ -94,7 +100,28 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "average",
+            None,
             np.array([13 / 4, 19 / 3]),
+        ),
+        (
+            # average downsample 1D array
+            np.array([1, 4, 6, 2, 3, 5, 11]),
+            7,
+            2,
+            0,
+            "average",
+            np.float32,
+            np.array([13 / 4, 19 / 3], dtype=np.float32),
+        ),
+        (
+            # average downsample 1D array
+            np.array([1, 4, 6, 2, 3, 5, 11], dtype=np.uint16),
+            7,
+            2,
+            0,
+            "average",
+            None,
+            np.array([13 / 4, 19 / 3], dtype=np.float32),
         ),
         (
             # average downsample ND array
@@ -105,6 +132,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "average",
+            None,
             np.array([[13 / 4, 4], [19 / 3, 22 / 3]]),
         ),
         (
@@ -114,6 +142,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             1,
             0,
             "average",
+            None,
             np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
         ),
         (
@@ -123,6 +152,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             1,
             0,
             "average",
+            None,
             np.array([[3.0, 4.0]]),
         ),
         (
@@ -132,12 +162,13 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "maximum",
+            None,
             np.array([6, 11]),
         ),
     ],
 )
 def test_downsample(
-    array, input_fps, output_fps, random_seed, strategy, expected
+    array, input_fps, output_fps, random_seed, strategy, dtype, expected
 ):
     """Test downsample_array"""
     array_out = au.downsample_array(
@@ -146,6 +177,7 @@ def test_downsample(
         output_fps=output_fps,
         strategy=strategy,
         random_seed=random_seed,
+        dtype=dtype,
     )
     assert np.array_equal(expected, array_out)
 

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -165,6 +165,26 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             None,
             np.array([6, 11]),
         ),
+        (
+            # median downsample 1D array
+            np.array([1, 4, 6, 2, 3, 5, 11]),
+            7,
+            2,
+            0,
+            "median",
+            None,
+            np.array([3, 5]),
+        ),
+        (
+            # median downsample ND array
+            np.arange(200000).reshape(100, 2000),
+            50,
+            1,
+            0,
+            "median",
+            None,
+            np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
+        ),
     ],
 )
 def test_downsample(
@@ -187,8 +207,11 @@ def test_downsample(
     ("average",
      np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
      ),
-    ("maximum",
+    ("max",
      np.array([np.arange(98000, 100000), np.arange(198000, 200000)]),
+     ),
+    ("median",
+     np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
      ),
 ],
 )
@@ -207,10 +230,9 @@ def test_downsample_h5(strategy, expected):
                 random_seed=0,
             )
             assert np.array_equal(expected, array_out)
-            if strategy == "average":
-                f = au._mean_of_group
-            else:
-                f = au._max_of_group
+            f = {"average": au._mean_of_group,
+                 "max": au._max_of_group,
+                 "median": au._median_of_group}[strategy]
             array_out = np.array(list(map(
                 lambda i: f(i, array.file.filename, array.name, 50),
                 range(0, 100, 50))))

--- a/tests/test_summary_images.py
+++ b/tests/test_summary_images.py
@@ -62,3 +62,25 @@ def test_pnr_image(ds, method):
     assert_array_almost_equal(
         np.ones((3, 3)), output / expected, decimal=decimal
     )
+
+
+@pytest.mark.parametrize(
+    "ds, bs",
+    list(product([1, 2, 5], [2, 10, 100])),
+)
+def test_max_image(ds, bs):
+    """Test max_image"""
+    output = si.max_image(
+        np.arange(180).reshape(20, 3, 3), downscale=ds, batch_size=bs
+    )
+    expected = {1: 171, 2: 166.5, 5: 153}[ds] + np.arange(9).reshape(3, 3)
+    assert_array_almost_equal(expected, output)
+
+
+@pytest.mark.parametrize("bs", [2, 10, 100])
+def test_mean_image(bs):
+    """Test mean_image"""
+    data = np.arange(180).reshape(20, 3, 3)
+    output = si.mean_image(data, batch_size=bs)
+    expected = data.mean(0)
+    assert_array_almost_equal(expected, output)


### PR DESCRIPTION
Adds efficient parallelized computation of mean and max summary images without loading the entire movie in RAM.

Adds support for colored movies to `video_utils.encode_video()`, e.g. for overlaying colorful ROI contours.

The returned output.dtype of `array_utils.downsample_array()` had the odd behavior to differ dependent on serial or parallel processing. With this PR the output.dtype is always the same as the input.dtype except for the 'mean' and 'median' strategy. In the latter cases, an array of type float32 will be created if the input precision is less than 32 bits; otherwise, it will be float64.
'Mean' downscaling is often applied to uint16 movies for which float64 precision (the old default) is unnecessary but would require large RAM. 