### PR TITLE
Dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ dynamic = ["version"]
 
 dependencies = [
     'h5py',
-    'imageio_ffmpeg',
-    'numpy',
+    'imageio-ffmpeg',
     'pandas',
-    'scipy',
+    'scikit-image',
     'torch'
 ]
 

--- a/src/aind_ophys_utils/array_utils.py
+++ b/src/aind_ophys_utils/array_utils.py
@@ -1,6 +1,7 @@
 """ Utils to manipulate arrays """
 
 import warnings
+from functools import partial
 from itertools import product
 from multiprocessing.pool import Pool, ThreadPool
 from typing import Optional, Union
@@ -104,19 +105,9 @@ def _select(x, axis, which):
     return res
 
 
-def _nanfirst(x, axis):
-    """Auxiliary function to compute nanfirst"""
-    return _select(x, axis, "first")
-
-
-def _nanlast(x, axis):
-    """Auxiliary function to compute nanlast"""
-    return _select(x, axis, "last")
-
-
-def _nanmid(x, axis):
-    """Auxiliary function to compute nanmid"""
-    return _select(x, axis, "mid")
+_nanfirst = partial(_select, which="first")
+_nanlast = partial(_select, which="last")
+_nanmid = partial(_select, which="mid")
 
 
 def subsample_array(
@@ -296,7 +287,7 @@ def downsample_array(
     if factors is None:
         # Emit a DeprecationWarning
         warnings.warn(
-            "The use of input_fps and output_fps is is deprecated and "
+            "The use of input_fps and output_fps is deprecated and "
             "will be removed in future versions. Use factors instead",
             DeprecationWarning,
             stacklevel=2,

--- a/src/aind_ophys_utils/array_utils.py
+++ b/src/aind_ophys_utils/array_utils.py
@@ -129,7 +129,7 @@ def subsample_array(
     strategy: str
         Subsampling strategy. 'first', 'last', 'mid'/'middle'.
     skipna: bool
-        Exclude NA/null values when computing the result.
+        Exclude NaN values when computing the result.
     n_jobs: Optional[int]
         The number of jobs to run in parallel.
     dtype: Optional[type]
@@ -269,7 +269,7 @@ def downsample_array(
         Downsampling strategy. 'max'/'maximum', 'mean'/'average', 'median',
         'first', 'last', 'mid'/'middle'.
     skipna: bool
-        Exclude NA/null values when computing the result.
+        Exclude NaN values when computing the result.
     n_jobs: Optional[int]
         The number of jobs to run in parallel.
     dtype: Optional[type]

--- a/src/aind_ophys_utils/array_utils.py
+++ b/src/aind_ophys_utils/array_utils.py
@@ -109,21 +109,8 @@ def downsample_array(
         "first": lambda arr, idx: arr[idx[0]],
         "last": lambda arr, idx: arr[idx[-1]],
     }
-    # if dtype is None and array.dtype.itemsize < 4:
-    #     sampling_strategies["mean"] = \
-    #         lambda arr, idx: arr[idx].mean(axis=0).astype(np.float32)
-    #     sampling_strategies["median"] = \
-    #         lambda arr, idx: np.median(arr[idx], axis=0).astype(np.float32)
-    # if dtype is not None:
-    #     sampling_strategies["mean"] = \
-    #         lambda arr, idx: arr[idx].mean(axis=0).astype(dtype)
-    #     sampling_strategies["median"] = \
-    #         lambda arr, idx: np.median(arr[idx], axis=0).astype(dtype)
-
-    mean_dtype = None
-    if dtype is not None:
-        mean_dtype = dtype
-    elif array.dtype.itemsize < 4:
+    mean_dtype = dtype
+    if dtype is None and array.dtype.itemsize < 4:
         mean_dtype = np.float32
     if mean_dtype is not None:
         sampling_strategies["mean"] = \

--- a/src/aind_ophys_utils/array_utils.py
+++ b/src/aind_ophys_utils/array_utils.py
@@ -255,7 +255,7 @@ def downsample_array(
     array: Union[h5py.Dataset, np.ndarray],
     input_fps: float = 31.0,
     output_fps: float = 4.0,
-    factors: tuple = None,
+    factors: Union[tuple, int] = None,
     strategy: str = "mean",
     skipna: bool = False,
     n_jobs: Optional[int] = None,
@@ -271,8 +271,9 @@ def downsample_array(
         Frames-per-second of the input array [deprecated]
     output_fps: float
         Frames-per-second of the output array [deprecated]
-    factors : array_like
-        Array containing down-sampling integer factor along each axis.
+    factors : tuple or int
+        Tuple containing down-sampling integer factor along each axis.
+        If int, will downsample only along the first axis.
     strategy: str
         Downsampling strategy. 'max'/'maximum', 'mean'/'average', 'median',
         'first', 'last', 'mid'/'middle'.
@@ -305,6 +306,8 @@ def downsample_array(
         factors = (n_frames_from_hz(input_fps, output_fps),) + (1,) * (
             len(array.shape) - 1
         )
+    if isinstance(factors, int):
+        factors = (factors,) + (1,) * (len(array.shape) - 1)
 
     if strategy in ("first", "last", "mid", "middle"):
         # these strategies that subsample and thus require reading

--- a/src/aind_ophys_utils/summary_images.py
+++ b/src/aind_ophys_utils/summary_images.py
@@ -187,7 +187,7 @@ def max_image(
     """
     if downscale > 1:
         mov = downsample_array(mov, downscale, 1)
-    return downsample_array(mov, batch_size, 1, "maximum").max(0)
+    return downsample_array(mov, batch_size, 1, strategy="max").max(0)
 
 
 def mean_image(

--- a/src/aind_ophys_utils/summary_images.py
+++ b/src/aind_ophys_utils/summary_images.py
@@ -180,35 +180,8 @@ def pnr_image(
     if downscale > 1:
         mov = downsample_array(mov, factors=downscale)
     noise = noise_std(mov, method, axis=0, device=device)
-    return (np.max(mov, 0) - np.min(mov, 0)) / noise
+    return (np.max(mov, 0) - np.median(mov, 0)) / noise
 
-
-# def max_image(
-#     mov: Union[h5py.Dataset, np.ndarray],
-#     downscale: int = 1,
-#     batch_size: int = 500,
-# ) -> np.ndarray:
-#     """Computes the maximum image for the input dataset mov.
-#     Downscales the movie (optionally), and efficiently calculates
-#     the maximum image by combining parallely processed batches.
-
-#     Parameters
-#     ----------
-#     mov: Union[h5py.Dataset, np.ndarray]
-#         Input movie data.
-#     downscale: int
-#         Temporal downscale factor.
-#     batch_size: int
-#         Number of frames in each batch.
-
-#     Returns
-#     -------
-#     max: ndarray
-#         max image
-#     """
-#     if downscale > 1:
-#         mov = downsample_array(mov, factors=downscale)
-#     return downsample_array(mov, factors=batch_size, strategy="max").max(0)
 
 def max_image(
     mov: Union[h5py.Dataset, np.ndarray],

--- a/src/aind_ophys_utils/summary_images.py
+++ b/src/aind_ophys_utils/summary_images.py
@@ -316,6 +316,6 @@ def _nan_sum(mov, f, batch_size):
     """
     return np.nansum(_downsample_array(
         mov,
-        fun=lambda x, axis: np.nansum(f(x), axis),
+        fun=lambda x, axis: np.nansum(f(x.astype(float)), axis),
         factors=(batch_size, 1, 1)
     ), 0)

--- a/src/aind_ophys_utils/summary_images.py
+++ b/src/aind_ophys_utils/summary_images.py
@@ -113,7 +113,7 @@ def max_corr_image(
     """
     T = mov.shape[0]
     if downscale > 1:
-        mov = downsample_array(mov, downscale, 1)
+        mov = downsample_array(mov, factors=downscale)
         T = mov.shape[0]
     n_bins = max(1, int(np.round(T / bin_size)))
     bins = np.round(np.linspace(0, T, n_bins + 1)).astype(int)
@@ -157,7 +157,7 @@ def pnr_image(
         peak-to-noise ratio (PNR) image
     """
     if downscale > 1:
-        mov = downsample_array(mov, downscale, 1)
+        mov = downsample_array(mov, factors=downscale)
     noise = noise_std(mov, method, axis=0, device=device)
     return (np.max(mov, 0) - np.min(mov, 0)) / noise
 
@@ -186,8 +186,8 @@ def max_image(
         max image
     """
     if downscale > 1:
-        mov = downsample_array(mov, downscale, 1)
-    return downsample_array(mov, batch_size, 1, strategy="max").max(0)
+        mov = downsample_array(mov, factors=downscale)
+    return downsample_array(mov, factors=batch_size, strategy="max").max(0)
 
 
 def mean_image(
@@ -209,7 +209,7 @@ def mean_image(
     max: ndarray
         max image
     """
-    d = downsample_array(mov, batch_size, 1)
+    d = downsample_array(mov, factors=batch_size)
     w = np.ones(d.shape[0])
     smaller_last_batch = mov.shape[0] % batch_size
     if smaller_last_batch:

--- a/src/aind_ophys_utils/video_utils.py
+++ b/src/aind_ophys_utils/video_utils.py
@@ -53,6 +53,7 @@ def encode_video(
     bitrate: str = "0",
     crf: int = 20,
     cpu_used: int = 4,
+    color: bool = False,
 ) -> str:
     """Encode a video with vp9 codec via imageio-ffmpeg
 
@@ -76,6 +77,8 @@ def encode_video(
         Sets how efficient the compression will be, by default 4. Values can
         be between 0 and 5. Higher values increase encoding speed at the
         expense of having some impact on quality and rate control accuracy.
+    color : bool, optional
+        Whether the input video is color or grayscale, by default False
 
     Returns
     -------
@@ -89,7 +92,7 @@ def encode_video(
     writer = mpg.write_frames(
         output_path,
         video_shape,
-        pix_fmt_in="gray8",
+        pix_fmt_in="rgb24" if color else "gray8",
         pix_fmt_out="yuv420p",
         codec="libvpx-vp9",
         fps=fps,

--- a/src/aind_ophys_utils/video_utils.py
+++ b/src/aind_ophys_utils/video_utils.py
@@ -12,8 +12,7 @@ def downsample_h5_video(
     video_path: Path,
     input_fps: float = 31.0,
     output_fps: float = 4.0,
-    strategy: str = "average",
-    random_seed: int = 0,
+    strategy: str = "mean",
 ) -> np.ndarray:
     """Opens an h5 file and downsamples dataset 'data'
     along axis=0
@@ -22,18 +21,15 @@ def downsample_h5_video(
     ----------
         video_path: pathlib.Path
             path to an h5 video. Should have dataset 'data'. For video,
-            assumes dimensions [time, width, height] and downsampling
+            assumes dimensions [time, height, width] and downsampling
             applies to time.
         input_fps: float
             frames-per-second of the input array
         output_fps: float
             frames-per-second of the output array
         strategy: str
-            downsampling strategy. 'random', 'maximum', 'average',
-            'first', 'last'. Note 'maximum' is not defined for
-            multi-dimensional arrays
-        random_seed: int
-            passed to numpy.random.default_rng if strategy is 'random'
+            downsampling strategy. 'max', 'mean', 'median',
+            'first', 'last', 'mid'.
 
     Returns:
         video_out: numpy.ndarray
@@ -41,7 +37,7 @@ def downsample_h5_video(
     """
     with h5py.File(video_path, "r") as h5f:
         video_out = downsample_array(
-            h5f["data"], input_fps, output_fps, strategy, random_seed
+            h5f["data"], input_fps, output_fps, strategy=strategy
         )
     return video_out
 

--- a/src/aind_ophys_utils/video_utils.py
+++ b/src/aind_ophys_utils/video_utils.py
@@ -1,5 +1,6 @@
 """ Utils for video generation """
 from pathlib import Path
+from typing import Union
 
 import h5py
 import imageio_ffmpeg as mpg
@@ -43,7 +44,7 @@ def downsample_h5_video(
 
 
 def encode_video(
-    video: np.ndarray,
+    video: Union[h5py.Dataset, np.ndarray],
     output_path: str,
     fps: float,
     bitrate: str = "0",
@@ -55,7 +56,7 @@ def encode_video(
 
     Parameters
     ----------
-    video : np.ndarray
+    video : h5py.Dataset or numpy.ndarray
         Video to be encoded
     output_path : str
         Desired output path for encoded video

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -25,7 +25,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
 
 
 @pytest.mark.parametrize(
-    ("array, input_fps, output_fps, random_seed, strategy, expected"),
+    ("array, input_fps, output_fps, random_seed, strategy, dtype, expected"),
     [
         (
             # random downsample 1D array
@@ -34,6 +34,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "random",
+            None,
             np.array([2, 5]),
         ),
         (
@@ -45,6 +46,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "random",
+            None,
             np.array([[2, 1], [5, 8]]),
         ),
         (
@@ -54,6 +56,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "first",
+            None,
             np.array([1, 3]),
         ),
         (
@@ -65,6 +68,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "first",
+            None,
             np.array([[1, 3], [3, 2]]),
         ),
         (
@@ -74,6 +78,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "last",
+            None,
             np.array([2, 11]),
         ),
         (
@@ -85,6 +90,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "last",
+            None,
             np.array([[2, 1], [11, 12]]),
         ),
         (
@@ -94,7 +100,28 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "average",
+            None,
             np.array([13 / 4, 19 / 3]),
+        ),
+        (
+            # average downsample 1D array
+            np.array([1, 4, 6, 2, 3, 5, 11]),
+            7,
+            2,
+            0,
+            "average",
+            np.float32,
+            np.array([13 / 4, 19 / 3], dtype=np.float32),
+        ),
+        (
+            # average downsample 1D array
+            np.array([1, 4, 6, 2, 3, 5, 11], dtype=np.uint16),
+            7,
+            2,
+            0,
+            "average",
+            None,
+            np.array([13 / 4, 19 / 3], dtype=np.float32),
         ),
         (
             # average downsample ND array
@@ -105,6 +132,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "average",
+            None,
             np.array([[13 / 4, 4], [19 / 3, 22 / 3]]),
         ),
         (
@@ -114,6 +142,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             1,
             0,
             "average",
+            None,
             np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
         ),
         (
@@ -123,6 +152,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             1,
             0,
             "average",
+            None,
             np.array([[3.0, 4.0]]),
         ),
         (
@@ -132,12 +162,13 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             2,
             0,
             "maximum",
+            None,
             np.array([6, 11]),
         ),
     ],
 )
 def test_downsample(
-    array, input_fps, output_fps, random_seed, strategy, expected
+    array, input_fps, output_fps, random_seed, strategy, dtype, expected
 ):
     """Test downsample_array"""
     array_out = au.downsample_array(
@@ -146,6 +177,7 @@ def test_downsample(
         output_fps=output_fps,
         strategy=strategy,
         random_seed=random_seed,
+        dtype=dtype,
     )
     assert np.array_equal(expected, array_out)
 

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -165,6 +165,26 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             None,
             np.array([6, 11]),
         ),
+        (
+            # median downsample 1D array
+            np.array([1, 4, 6, 2, 3, 5, 11]),
+            7,
+            2,
+            0,
+            "median",
+            None,
+            np.array([3, 5]),
+        ),
+        (
+            # median downsample ND array
+            np.arange(200000).reshape(100, 2000),
+            50,
+            1,
+            0,
+            "median",
+            None,
+            np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
+        ),
     ],
 )
 def test_downsample(
@@ -187,8 +207,11 @@ def test_downsample(
     ("average",
      np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
      ),
-    ("maximum",
+    ("max",
      np.array([np.arange(98000, 100000), np.arange(198000, 200000)]),
+     ),
+    ("median",
+     np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
      ),
 ],
 )
@@ -207,10 +230,9 @@ def test_downsample_h5(strategy, expected):
                 random_seed=0,
             )
             assert np.array_equal(expected, array_out)
-            if strategy == "average":
-                f = au._mean_of_group
-            else:
-                f = au._max_of_group
+            f = {"average": au._mean_of_group,
+                 "max": au._max_of_group,
+                 "median": au._median_of_group}[strategy]
             array_out = np.array(list(map(
                 lambda i: f(i, array.file.filename, array.name, 50),
                 range(0, 100, 50))))

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -412,7 +412,7 @@ def test_decimate_video(input_fps):
     expected = np.array(expected)
 
     actual = au.downsample_array(
-        video, input_fps=input_fps, output_fps=1, strategy="average"
+        video, factors=input_fps, strategy="average"
     )
     np.testing.assert_array_equal(expected, actual)
 

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -25,48 +25,24 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
 
 
 @pytest.mark.parametrize(
-    ("array, input_fps, output_fps, random_seed, strategy, dtype, expected"),
+    ("array, input_fps, output_fps, strategy, dtype, expected"),
     [
-        (
-            # random downsample 1D array
-            np.array([1, 4, 6, 2, 3, 5, 11]),
-            7,
-            2,
-            0,
-            "random",
-            None,
-            np.array([2, 5]),
-        ),
-        (
-            # random downsample ND array
-            np.array(
-                [[1, 3], [4, 4], [6, 8], [2, 1], [3, 2], [5, 8], [11, 12]]
-            ),
-            7,
-            2,
-            0,
-            "random",
-            None,
-            np.array([[2, 1], [5, 8]]),
-        ),
         (
             # first downsample 1D array
             np.array([1, 4, 6, 2, 3, 5, 11]),
             7,
             2,
-            0,
             "first",
             None,
             np.array([1, 3]),
         ),
         (
-            # random downsample ND array
+            # first downsample ND array
             np.array(
                 [[1, 3], [4, 4], [6, 8], [2, 1], [3, 2], [5, 8], [11, 12]]
             ),
             7,
             2,
-            0,
             "first",
             None,
             np.array([[1, 3], [3, 2]]),
@@ -76,10 +52,9 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.array([1, 4, 6, 2, 3, 5, 11]),
             7,
             2,
-            0,
             "last",
             None,
-            np.array([2, 11]),
+            np.array([2]),
         ),
         (
             # last downsample ND array
@@ -88,17 +63,35 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             ),
             7,
             2,
-            0,
             "last",
             None,
-            np.array([[2, 1], [11, 12]]),
+            np.array([[2, 1]]),
+        ),
+        (
+            # mid downsample 1D array
+            np.array([1, 4, 6, 2, 3, 5, 11]),
+            7,
+            2,
+            "mid",
+            None,
+            np.array([6, 11]),
+        ),
+        (
+            # mid downsample ND array
+            np.array(
+                [[1, 3], [4, 4], [6, 8], [2, 1], [3, 2], [5, 8], [11, 12]]
+            ),
+            7,
+            2,
+            "middle",
+            None,
+            np.array([[6, 8], [11, 12]]),
         ),
         (
             # average downsample 1D array
             np.array([1, 4, 6, 2, 3, 5, 11]),
             7,
             2,
-            0,
             "average",
             None,
             np.array([13 / 4, 19 / 3]),
@@ -108,7 +101,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.array([1, 4, 6, 2, 3, 5, 11]),
             7,
             2,
-            0,
             "average",
             np.float32,
             np.array([13 / 4, 19 / 3], dtype=np.float32),
@@ -118,7 +110,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.array([1, 4, 6, 2, 3, 5, 11], dtype=np.uint16),
             7,
             2,
-            0,
             "average",
             None,
             np.array([13 / 4, 19 / 3], dtype=np.float32),
@@ -130,7 +121,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             ),
             7,
             2,
-            0,
             "average",
             None,
             np.array([[13 / 4, 4], [19 / 3, 22 / 3]]),
@@ -140,7 +130,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.arange(200000).reshape(100, 2000),
             50,
             1,
-            0,
             "average",
             None,
             np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
@@ -150,7 +139,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.array([[1, 2], [3, 4], [5, 6]]),
             10,
             1,
-            0,
             "average",
             None,
             np.array([[3.0, 4.0]]),
@@ -160,7 +148,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.array([1, 4, 6, 2, 3, 5, 11]),
             7,
             2,
-            0,
             "maximum",
             None,
             np.array([6, 11]),
@@ -170,7 +157,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.array([1, 4, 6, 2, 3, 5, 11]),
             7,
             2,
-            0,
             "median",
             None,
             np.array([3, 5]),
@@ -180,7 +166,6 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
             np.arange(200000).reshape(100, 2000),
             50,
             1,
-            0,
             "median",
             None,
             np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
@@ -188,7 +173,7 @@ def test_n_frames_from_hz(input_frame_rate, downsampled_frame_rate, expected):
     ],
 )
 def test_downsample(
-    array, input_fps, output_fps, random_seed, strategy, dtype, expected
+    array, input_fps, output_fps, strategy, dtype, expected
 ):
     """Test downsample_array"""
     array_out = au.downsample_array(
@@ -196,7 +181,6 @@ def test_downsample(
         input_fps=input_fps,
         output_fps=output_fps,
         strategy=strategy,
-        random_seed=random_seed,
         dtype=dtype,
     )
     assert np.array_equal(expected, array_out)
@@ -204,7 +188,7 @@ def test_downsample(
 
 @pytest.mark.parametrize(("strategy, expected"),
                          [
-    ("average",
+    ("mean",
      np.array([np.arange(49000, 51000), np.arange(149000, 151000)]),
      ),
     ("max",
@@ -226,35 +210,32 @@ def test_downsample_h5(strategy, expected):
                 array=array,
                 input_fps=50,
                 output_fps=1,
-                strategy=strategy,
-                random_seed=0,
+                strategy=strategy
             )
             assert np.array_equal(expected, array_out)
-            f = {"average": au._mean_of_group,
-                 "max": au._max_of_group,
-                 "median": au._median_of_group}[strategy]
+            f = {"mean": np.mean, "max": np.max, "median": np.median}[strategy]
             array_out = np.array(list(map(
-                lambda i: f(i, array.file.filename, array.name, 50),
+                lambda i: au._downsample_group(
+                    i, array.file.filename, array.name, (50, 1), f),
                 range(0, 100, 50))))
             assert np.array_equal(expected, array_out)
 
 
 @pytest.mark.parametrize(
-    ("array, input_fps, output_fps, random_seed, strategy, expected"),
+    ("array, input_fps, output_fps, strategy, expected"),
     [
         (
             # upsampling not defined
             np.array([1, 4, 6, 2, 3, 5, 11]),
             7,
             11,
-            0,
             "maximum",
             np.array([6, 11]),
         ),
     ],
 )
 def test_downsample_exceptions(
-    array, input_fps, output_fps, random_seed, strategy, expected
+    array, input_fps, output_fps, strategy, expected
 ):
     """Test Exception raised by downsample_array"""
     with pytest.raises(ValueError):
@@ -263,7 +244,6 @@ def test_downsample_exceptions(
             input_fps=input_fps,
             output_fps=output_fps,
             strategy=strategy,
-            random_seed=random_seed,
         )
 
 

--- a/tests/test_signal_utils.py
+++ b/tests/test_signal_utils.py
@@ -121,7 +121,7 @@ def test_robust_std(x, expected, axis):
                     [np.random.randn(20, 10000), [1] * 20, None],  # just noise
                     [np.random.randn(20, 10000), [1] * 20, 1],  # just noise
                     [
-                        np.random.randn(20, 10000) \
+                        np.random.randn(20, 10000)
                         + np.sin(  # Typical: noise+signal
                             np.linspace(0, 100, 200000).reshape(20, 10000)
                         ),

--- a/tests/test_summary_images.py
+++ b/tests/test_summary_images.py
@@ -40,7 +40,7 @@ def test_local_correlations(array, expected):
 def test_max_corr_image(ds, bs, eight):
     """Test max_corr_image"""
     output = si.max_corr_image(
-        np.arange(180).reshape(20, 3, 3), downscale=ds, bin_size=bs,
+        np.arange(270).reshape(30, 3, 3), downscale=ds, bin_size=bs,
         eight_neighbours=eight
     )
     expected = np.ones((3, 3))

--- a/tests/test_summary_images.py
+++ b/tests/test_summary_images.py
@@ -66,7 +66,7 @@ def test_pnr_image(ds, method):
 
 @pytest.mark.parametrize(
     "ds, bs",
-    list(product([1, 2, 5], [2, 10, 100])),
+    list(product([1, 2, 5], [2, 7, 10, 100])),
 )
 def test_max_image(ds, bs):
     """Test max_image"""
@@ -77,10 +77,23 @@ def test_max_image(ds, bs):
     assert_array_almost_equal(expected, output)
 
 
-@pytest.mark.parametrize("bs", [2, 10, 100])
+@pytest.mark.parametrize("bs", [2, 7, 10, 100])
 def test_mean_image(bs):
     """Test mean_image"""
     data = np.arange(180).reshape(20, 3, 3)
     output = si.mean_image(data, batch_size=bs)
     expected = data.mean(0)
+    assert_array_almost_equal(expected, output)
+
+
+@pytest.mark.parametrize(
+    "ds, bs",
+    list(product([1, 2, 5], [2, 7, 10, 100])),
+)
+def test_var_image(ds, bs):
+    """Test var_image"""
+    output = si.var_image(
+        np.arange(180).reshape(20, 3, 3), downscale=ds, batch_size=bs
+    )
+    expected = {1: 2693.25, 2: 2673, 5: 2531.25}[ds] * np.ones((3, 3))
     assert_array_almost_equal(expected, output)

--- a/tests/test_summary_images.py
+++ b/tests/test_summary_images.py
@@ -65,35 +65,53 @@ def test_pnr_image(ds, method):
 
 
 @pytest.mark.parametrize(
-    "ds, bs",
-    list(product([1, 2, 5], [2, 7, 10, 100])),
+    "ds, bs, skipna",
+    list(product([1, 2, 5], [2, 7, 10, 100], [False, True])),
 )
-def test_max_image(ds, bs):
+def test_max_image(ds, bs, skipna):
     """Test max_image"""
-    output = si.max_image(
-        np.arange(180).reshape(20, 3, 3), downscale=ds, batch_size=bs
-    )
-    expected = {1: 171, 2: 166.5, 5: 153}[ds] + np.arange(9).reshape(3, 3)
-    assert_array_almost_equal(expected, output)
-
-
-@pytest.mark.parametrize("bs", [2, 7, 10, 100])
-def test_mean_image(bs):
-    """Test mean_image"""
-    data = np.arange(180).reshape(20, 3, 3)
-    output = si.mean_image(data, batch_size=bs)
-    expected = data.mean(0)
+    data = np.arange(180.).reshape(20, 3, 3)
+    data[-1, 0, 0] = np.nan
+    output = si.max_image(data, downscale=ds, batch_size=bs, skipna=skipna)
+    expected = {1: 171., 2: 166.5, 5: 153.}[ds] + np.arange(9).reshape(3, 3)
+    expected[0, 0] = {1: 162, 2: 162, 5: 148.5}[ds] if skipna else np.nan
     assert_array_almost_equal(expected, output)
 
 
 @pytest.mark.parametrize(
-    "ds, bs",
-    list(product([1, 2, 5], [2, 7, 10, 100])),
+    "bs, skipna",
+    list(product([2, 7, 10, 100], [False, True])),
 )
-def test_var_image(ds, bs):
+def test_mean_image(bs, skipna):
+    """Test mean_image"""
+    data = np.arange(180.).reshape(20, 3, 3)
+    data[0, 0, 0] = np.nan
+    output = si.mean_image(data, batch_size=bs, skipna=skipna)
+    expected = np.nanmean(data, 0) if skipna else data.mean(0)
+    assert_array_almost_equal(expected, output)
+
+
+@pytest.mark.parametrize(
+    "ds, bs, skipna",
+    list(product([1, 2, 5], [2, 7, 10, 100], [False, True])),
+)
+def test_var_image(ds, bs, skipna):
     """Test var_image"""
+    data = np.arange(180.).reshape(20, 3, 3)
+    data[0, 0, 0] = np.nan
     output = si.var_image(
-        np.arange(180).reshape(20, 3, 3), downscale=ds, batch_size=bs
+        data, downscale=ds, batch_size=bs, skipna=skipna
     )
     expected = {1: 2693.25, 2: 2673, 5: 2531.25}[ds] * np.ones((3, 3))
+    expected[0, 0] = {1: 2430, 2: 2160, 5: 1350}[ds] if skipna else np.nan
+    assert_array_almost_equal(expected, output)
+
+
+@pytest.mark.parametrize("bs", [2, 7, 10, 100])
+def test_nan_sum(bs):
+    """Test var_image"""
+    mov = np.arange(180.).reshape(20, 3, 3)
+    mov[0, 0, 0] = np.nan
+    output = si._nan_sum(mov, lambda x: x, bs)
+    expected = np.nansum(mov, 0)
     assert_array_almost_equal(expected, output)

--- a/tests/test_summary_images.py
+++ b/tests/test_summary_images.py
@@ -62,3 +62,25 @@ def test_pnr_image(ds, method):
     assert_array_almost_equal(
         np.ones((3, 3)), output / expected, decimal=decimal
     )
+
+
+@pytest.mark.parametrize(
+    "ds, bs",
+    list(product([1, 2, 5], [2, 10, 100])),
+)
+def test_max_image(ds, bs):
+    """Test max_image"""
+    output = si.max_image(
+        np.arange(180).reshape(20, 3, 3), downscale=ds, batch_size=bs
+    )
+    expected = {1: 171, 2: 166.5, 5: 153}[ds] + np.arange(9).reshape(3, 3)
+    assert_array_almost_equal(expected, output)
+
+
+@pytest.mark.parametrize("bs", [2, 10, 100])
+def test_mean_image(bs):
+    """Test mean_image"""
+    data = np.arange(180).reshape(20, 3, 3)
+    output = si.mean_image(data, batch_size=bs)
+    expected = data.mean(0)
+    assert_array_almost_equal(expected, output)


### PR DESCRIPTION
**See commit messages**

The major changes happened in `downsample_array`, which now supports `nans` and downsampling along all dimensions by given `factors`, not just the first (usually time).

Supporting subsampling and downscaling, nans and no-nans, compressed and uncompressed .h5, makes this function quite complex (I even ran into flake8's `Function is too complex (C901)`, but managed to reduce complexity) but fast and efficient (low RAM, multi-core)   
