### PR TITLE
dff config to dataclass

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,4 @@ exclude =
     __pycache__,
     build
 max-complexity = 10
+max-line-length = 100

--- a/src/aind_ophys_utils/baseline_fitting.py
+++ b/src/aind_ophys_utils/baseline_fitting.py
@@ -277,7 +277,7 @@ class TukeyBiweight(AsymmetricTukeyBiweight):
 # -----------------------------
 #  Fitting Functions
 # -----------------------------
-def nonlinear_fit(
+def nonlinear_fit(  # noqa: C901
     # --- data / model ---
     trace: np.ndarray,
     t: np.ndarray,
@@ -599,7 +599,7 @@ def nonlinear_fit(
     _bnd_list = list(bounds) if bounds else [(None, None)] * len(np.asarray(x0))
     lo_bb = _bnd_list[_B_BRIGHT_IDX][0]
     _bnd_list[_B_BRIGHT_IDX] = (lo_bb if lo_bb is not None else 0.0,
-                                 b_bright_ub if b_bright_ub > 0 else None)
+                                b_bright_ub if b_bright_ub > 0 else None)
     con_bounds = tuple(_bnd_list)
 
     x0_B_np = x_2_np.copy()
@@ -1021,7 +1021,7 @@ def fit_baseline(
 # -----------------------------
 #  Plotting Functions
 # -----------------------------
-def plot_dff(F, F0, F0trend, t=None, zoom_duration=60.0, roi_id=None):
+def plot_dff(F, F0, F0trend, t=None, zoom_duration=60.0, roi_id=None):  # noqa: C901
     import matplotlib.pyplot as plt
     from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
     if t is None:

--- a/src/aind_ophys_utils/dff_triexp.py
+++ b/src/aind_ophys_utils/dff_triexp.py
@@ -752,12 +752,12 @@ def dff(
     F2d = np.atleast_2d(np.asarray(F, dtype=np.float64))
     N, T = F2d.shape
 
-    n_skip             = config.n_skip
-    t_rel              = config.t_rel
-    x0_all             = config.x0_all
-    bounds_all         = config.bounds_all
-    sigma_all          = config.sigma_all
-    min_frac_below_f0  = config.min_frac_below_f0
+    n_skip = config.n_skip
+    t_rel = config.t_rel
+    x0_all = config.x0_all
+    bounds_all = config.bounds_all
+    sigma_all = config.sigma_all
+    min_frac_below_f0 = config.min_frac_below_f0
     tukey_param_combos = config.tukey_param_combos
 
     F_fit = F2d[:, n_skip:]
@@ -775,8 +775,8 @@ def dff(
         )
 
     winner_F0_fit = np.stack([r[0] for r in rows])   # (N, T_fit)
-    params_all    = np.stack([r[1] for r in rows])   # (N, 7)
-    logs          = [r[2] for r in rows]
+    params_all = np.stack([r[1] for r in rows])   # (N, 7)
+    logs = [r[2] for r in rows]
 
     F0_full = np.empty((N, T), dtype=np.float32)
     if n_skip > 0:

--- a/src/aind_ophys_utils/dff_triexp.py
+++ b/src/aind_ophys_utils/dff_triexp.py
@@ -452,6 +452,28 @@ class DffConfig:
     tukey_param_combos: Tuple[Tuple[int, int], ...]
     params: dict = field(default_factory=dict)
 
+    @classmethod
+    def from_dict(cls, d: dict) -> "DffConfig":
+        """Build a DffConfig from a legacy dict (as returned by older versions
+        of ``set_dff_config``).  Missing ``min_frac_below_f0``,
+        ``tukey_param_combos``, and ``params`` keys fall back to defaults.
+        """
+        return cls(
+            n_skip=d["n_skip"],
+            t_rel=d["t_rel"],
+            x0_all=d["x0_all"],
+            bounds_all=d["bounds_all"],
+            sigma_all=d["sigma_all"],
+            min_frac_below_f0=float(d.get("min_frac_below_f0", 0.05)),
+            tukey_param_combos=tuple(
+                tuple(c) for c in d.get(
+                    "tukey_param_combos",
+                    ((2, 3), (2, 4), (2, 5), (3, 4), (3, 5)),
+                )
+            ),
+            params=d.get("params", {}),
+        )
+
 
 def set_dff_config(
     F: np.ndarray,
@@ -697,7 +719,7 @@ def set_dff_config(
 
 def dff(
     F: np.ndarray,
-    config: DffConfig,
+    config: "DffConfig | dict",
     n_jobs: int = -1,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list]:
     """Fit biexp_bright_v1 and return dFF, F0, noise_sd, params, and logs.
@@ -706,9 +728,10 @@ def dff(
     ----------
     F : (N, T) or (T,) array
         Neuropil-corrected fluorescence (same array passed to set_dff_config).
-    config : DffConfig
-        Output of set_dff_config().  All model and fitting parameters are
-        read from config, including tukey_param_combos.
+    config : DffConfig or dict
+        Output of set_dff_config().  A legacy dict is also accepted and
+        converted via ``DffConfig.from_dict``.  All model and fitting
+        parameters are read from config, including tukey_param_combos.
     n_jobs : int
         Parallel workers (joblib). -1 = all CPUs, 1 = sequential.
 
@@ -722,6 +745,9 @@ def dff(
     logs : list[dict]          — per-ROI pass diagnostics (length N);
                                   for 1D input F, a single dict is returned instead
     """
+    if isinstance(config, dict):
+        config = DffConfig.from_dict(config)
+
     is_1d = F.ndim == 1
     F2d = np.atleast_2d(np.asarray(F, dtype=np.float64))
     N, T = F2d.shape

--- a/src/aind_ophys_utils/dff_triexp.py
+++ b/src/aind_ophys_utils/dff_triexp.py
@@ -55,7 +55,7 @@ aind_ophys_utils (for signal_utils.percentile_filter).
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
 import numpy as np
@@ -436,6 +436,11 @@ class DffConfig:
         Threshold for the low-F0 check in Pass 1.
     tukey_param_combos : tuple of (c_pos, c_neg) pairs
         Asymmetric Tukey biweight thresholds swept during fitting.
+    params : dict
+        Optional, unverified snapshot of the scalar inputs to
+        ``set_dff_config`` plus a few derived scalars (n_skip, t_max).
+        Intended as a JSON-loggable reproducibility record; not read by
+        ``dff()``.  Empty by default.
     """
 
     n_skip: int
@@ -445,6 +450,7 @@ class DffConfig:
     sigma_all: np.ndarray
     min_frac_below_f0: float
     tukey_param_combos: Tuple[Tuple[int, int], ...]
+    params: dict = field(default_factory=dict)
 
 
 def set_dff_config(
@@ -548,6 +554,10 @@ def set_dff_config(
             sigma_all          : (N,)      — per-ROI noise std (MAD)
             min_frac_below_f0  : float     — passed through to dff()
             tukey_param_combos : tuple     — passed through to dff()
+            params             : dict      — JSON-serializable snapshot of scalar
+                                              inputs + derived scalars (n_skip,
+                                              t_max).  For reproducibility logging;
+                                              not read by dff().
     """
     if not (0 <= min_frac_below_f0 < 1):
         raise ValueError(
@@ -660,6 +670,28 @@ def set_dff_config(
         sigma_all=sigma_all,
         min_frac_below_f0=min_frac_below_f0,
         tukey_param_combos=tukey_param_combos,
+        params={
+            "ts_provided":              bool(ts_provided),
+            "fs":                       float(fs) if not ts_provided else None,
+            "skip_initial_s":           float(skip_initial_s),
+            "n_skip":                   int(n_skip),
+            "t_max":                    float(t_max),
+            "b_inf_n_frames":           int(b_inf_n_frames),
+            "t_fast_init_s":            float(t_fast_init_s),
+            "b_slow_max_factor":        float(b_slow_max_factor),
+            "b_bright_max_factor":      float(b_bright_max_factor),
+            "b_fast_ptp_window_s":      float(b_fast_ptp_window_s),
+            "b_inf_lb_factor":          float(b_inf_lb_factor),
+            "t_fast_min_s":             float(t_fast_min_s),
+            "t_fast_max_s":             float(t_fast_max_s),
+            "t_slow_min_s":             float(t_slow_min_s),
+            "t_bright_min_s":           float(t_bright_min_s),
+            "t_slow_min_tmax_factor":   float(t_slow_min_tmax_factor),
+            "t_bright_min_tmax_factor": float(t_bright_min_tmax_factor),
+            "t_high_factor":            float(t_high_factor),
+            "min_frac_below_f0":        float(min_frac_below_f0),
+            "tukey_param_combos":       [list(c) for c in tukey_param_combos],
+        },
     )
 
 

--- a/src/aind_ophys_utils/dff_triexp.py
+++ b/src/aind_ophys_utils/dff_triexp.py
@@ -421,6 +421,11 @@ class DffConfig:
 
     Attributes
     ----------
+    params : dict
+        Optional, unverified snapshot of the scalar inputs to
+        ``set_dff_config`` plus a few derived scalars (n_skip, t_max).
+        Intended as a JSON-loggable reproducibility record; not read by
+        ``dff()``.  Empty by default.  Keyword-only.
     n_skip : int
         Frames removed from the start of the trace before fitting.
     t_rel : (T_fit,) np.ndarray
@@ -436,13 +441,9 @@ class DffConfig:
         Threshold for the low-F0 check in Pass 1.
     tukey_param_combos : tuple of (c_pos, c_neg) pairs
         Asymmetric Tukey biweight thresholds swept during fitting.
-    params : dict
-        Optional, unverified snapshot of the scalar inputs to
-        ``set_dff_config`` plus a few derived scalars (n_skip, t_max).
-        Intended as a JSON-loggable reproducibility record; not read by
-        ``dff()``.  Empty by default.
     """
 
+    params: dict = field(default_factory=dict, kw_only=True)
     n_skip: int
     t_rel: np.ndarray
     x0_all: np.ndarray
@@ -450,7 +451,6 @@ class DffConfig:
     sigma_all: np.ndarray
     min_frac_below_f0: float
     tukey_param_combos: Tuple[Tuple[int, int], ...]
-    params: dict = field(default_factory=dict)
 
 
 def set_dff_config(
@@ -545,6 +545,10 @@ def set_dff_config(
     -------
     DffConfig
         Frozen dataclass with fields:
+            params             : dict      — JSON-serializable snapshot of scalar
+                                              inputs + derived scalars (n_skip,
+                                              t_max).  For reproducibility logging;
+                                              not read by dff().
             n_skip             : int        — frames removed from the start
             t_rel              : (T_fit,)  — timestamps of the fit window relative
                                               to session start (s); starts at
@@ -554,10 +558,6 @@ def set_dff_config(
             sigma_all          : (N,)      — per-ROI noise std (MAD)
             min_frac_below_f0  : float     — passed through to dff()
             tukey_param_combos : tuple     — passed through to dff()
-            params             : dict      — JSON-serializable snapshot of scalar
-                                              inputs + derived scalars (n_skip,
-                                              t_max).  For reproducibility logging;
-                                              not read by dff().
     """
     if not (0 <= min_frac_below_f0 < 1):
         raise ValueError(
@@ -663,13 +663,6 @@ def set_dff_config(
     )
 
     return DffConfig(
-        n_skip=n_skip,
-        t_rel=t_rel,
-        x0_all=x0_all,
-        bounds_all=bounds_all,
-        sigma_all=sigma_all,
-        min_frac_below_f0=min_frac_below_f0,
-        tukey_param_combos=tukey_param_combos,
         params={
             "ts_provided":              bool(ts_provided),
             "fs":                       float(fs) if not ts_provided else None,
@@ -692,6 +685,13 @@ def set_dff_config(
             "min_frac_below_f0":        float(min_frac_below_f0),
             "tukey_param_combos":       [list(c) for c in tukey_param_combos],
         },
+        n_skip=n_skip,
+        t_rel=t_rel,
+        x0_all=x0_all,
+        bounds_all=bounds_all,
+        sigma_all=sigma_all,
+        min_frac_below_f0=min_frac_below_f0,
+        tukey_param_combos=tukey_param_combos,
     )
 
 

--- a/src/aind_ophys_utils/dff_triexp.py
+++ b/src/aind_ophys_utils/dff_triexp.py
@@ -452,28 +452,6 @@ class DffConfig:
     tukey_param_combos: Tuple[Tuple[int, int], ...]
     params: dict = field(default_factory=dict)
 
-    @classmethod
-    def from_dict(cls, d: dict) -> "DffConfig":
-        """Build a DffConfig from a legacy dict (as returned by older versions
-        of ``set_dff_config``).  Missing ``min_frac_below_f0``,
-        ``tukey_param_combos``, and ``params`` keys fall back to defaults.
-        """
-        return cls(
-            n_skip=d["n_skip"],
-            t_rel=d["t_rel"],
-            x0_all=d["x0_all"],
-            bounds_all=d["bounds_all"],
-            sigma_all=d["sigma_all"],
-            min_frac_below_f0=float(d.get("min_frac_below_f0", 0.05)),
-            tukey_param_combos=tuple(
-                tuple(c) for c in d.get(
-                    "tukey_param_combos",
-                    ((2, 3), (2, 4), (2, 5), (3, 4), (3, 5)),
-                )
-            ),
-            params=d.get("params", {}),
-        )
-
 
 def set_dff_config(
     F: np.ndarray,
@@ -729,8 +707,9 @@ def dff(
     F : (N, T) or (T,) array
         Neuropil-corrected fluorescence (same array passed to set_dff_config).
     config : DffConfig or dict
-        Output of set_dff_config().  A legacy dict is also accepted and
-        converted via ``DffConfig.from_dict``.  All model and fitting
+        Output of set_dff_config().  A dict is also accepted, in which case
+        it must contain keys matching the DffConfig field names exactly
+        (it is splatted via ``DffConfig(**config)``).  All model and fitting
         parameters are read from config, including tukey_param_combos.
     n_jobs : int
         Parallel workers (joblib). -1 = all CPUs, 1 = sequential.
@@ -746,7 +725,7 @@ def dff(
                                   for 1D input F, a single dict is returned instead
     """
     if isinstance(config, dict):
-        config = DffConfig.from_dict(config)
+        config = DffConfig(**config)
 
     is_1d = F.ndim == 1
     F2d = np.atleast_2d(np.asarray(F, dtype=np.float64))

--- a/src/aind_ophys_utils/dff_triexp.py
+++ b/src/aind_ophys_utils/dff_triexp.py
@@ -55,6 +55,7 @@ aind_ophys_utils (for signal_utils.percentile_filter).
 from __future__ import annotations
 
 import warnings
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import numpy as np
@@ -413,6 +414,39 @@ def _process_roi(
 # Public API
 # ---------------------------------------------------------------------------
 
+
+@dataclass(frozen=True)
+class DffConfig:
+    """Pre-computed per-ROI fit setup returned by ``set_dff_config``.
+
+    Attributes
+    ----------
+    n_skip : int
+        Frames removed from the start of the trace before fitting.
+    t_rel : (T_fit,) np.ndarray
+        Timestamps of the fit window relative to session start (s).
+    x0_all : (N, 7) np.ndarray
+        Per-ROI initial parameter vectors
+        [b_inf, b_slow, b_fast, b_bright, t_slow, t_fast, t_bright].
+    bounds_all : list[list[tuple]]
+        Per-ROI bounds — outer list length N, inner list of 7 (lb, ub) tuples.
+    sigma_all : (N,) np.ndarray
+        Per-ROI noise std (MAD).
+    min_frac_below_f0 : float
+        Threshold for the low-F0 check in Pass 1.
+    tukey_param_combos : tuple of (c_pos, c_neg) pairs
+        Asymmetric Tukey biweight thresholds swept during fitting.
+    """
+
+    n_skip: int
+    t_rel: np.ndarray
+    x0_all: np.ndarray
+    bounds_all: list
+    sigma_all: np.ndarray
+    min_frac_below_f0: float
+    tukey_param_combos: Tuple[Tuple[int, int], ...]
+
+
 def set_dff_config(
     F: np.ndarray,
     fs: float = 30.0,
@@ -441,11 +475,11 @@ def set_dff_config(
     tukey_param_combos: Tuple[Tuple[int, int], ...] = (
         (2, 3), (2, 4), (2, 5), (3, 4), (3, 5)
     ),
-) -> dict:
+) -> DffConfig:
     """Pre-compute per-ROI initial values, bounds, and noise estimates.
 
-    All parameters are plain numbers (no arrays). The returned dict is passed
-    directly to dff().
+    All parameters are plain numbers (no arrays). The returned DffConfig is
+    passed directly to dff().
 
     Parameters
     ----------
@@ -503,20 +537,17 @@ def set_dff_config(
 
     Returns
     -------
-    dict with keys:
-        params          : dict       — all scalar input parameters (JSON-serializable);
-                                       sufficient to reproduce this config given the
-                                       same F and ts arrays.  params["ts_provided"]
-                                       indicates which mode was used; params["fs"] is
-                                       None when ts was provided (fs was ignored)
-        n_skip          : int        — frames removed from the start
-        t_rel           : (T_fit,)  — timestamps of the fit window relative to
-                                       session start (s); starts at ~skip_initial_s
-        x0_all          : (N, 7)    — per-ROI initial parameter vectors
-        bounds_all      : list[N]   — per-ROI bounds (list of 7 (lb, ub) tuples)
-        sigma_all       : (N,)      — per-ROI noise std (MAD)
-        min_frac_below_f0 : float   — passed through to dff()
-        tukey_param_combos : tuple  — passed through to dff()
+    DffConfig
+        Frozen dataclass with fields:
+            n_skip             : int        — frames removed from the start
+            t_rel              : (T_fit,)  — timestamps of the fit window relative
+                                              to session start (s); starts at
+                                              ~skip_initial_s
+            x0_all             : (N, 7)    — per-ROI initial parameter vectors
+            bounds_all         : list[N]   — per-ROI bounds (list of 7 (lb, ub) tuples)
+            sigma_all          : (N,)      — per-ROI noise std (MAD)
+            min_frac_below_f0  : float     — passed through to dff()
+            tukey_param_combos : tuple     — passed through to dff()
     """
     if not (0 <= min_frac_below_f0 < 1):
         raise ValueError(
@@ -621,42 +652,20 @@ def set_dff_config(
         _noise_std(F_fit, method="mad", device="cpu"), dtype=np.float64
     )
 
-    return {
-        "params": {
-            "ts_provided":              bool(ts_provided),
-            "fs":                       float(fs) if not ts_provided else None,
-            "skip_initial_s":           float(skip_initial_s),
-            "n_skip":                   int(n_skip),
-            "t_max":                    float(t_max),
-            "b_inf_n_frames":           int(b_inf_n_frames),
-            "t_fast_init_s":            float(t_fast_init_s),
-            "b_slow_max_factor":        float(b_slow_max_factor),
-            "b_bright_max_factor":      float(b_bright_max_factor),
-            "b_fast_ptp_window_s":      float(b_fast_ptp_window_s),
-            "b_inf_lb_factor":          float(b_inf_lb_factor),
-            "t_fast_min_s":             float(t_fast_min_s),
-            "t_fast_max_s":             float(t_fast_max_s),
-            "t_slow_min_s":             float(t_slow_min_s),
-            "t_bright_min_s":           float(t_bright_min_s),
-            "t_slow_min_tmax_factor":   float(t_slow_min_tmax_factor),
-            "t_bright_min_tmax_factor": float(t_bright_min_tmax_factor),
-            "t_high_factor":            float(t_high_factor),
-            "min_frac_below_f0":        float(min_frac_below_f0),
-            "tukey_param_combos":       [list(c) for c in tukey_param_combos],
-        },
-        "n_skip":             n_skip,
-        "t_rel":              t_rel,
-        "x0_all":             x0_all,
-        "bounds_all":         bounds_all,
-        "sigma_all":          sigma_all,
-        "min_frac_below_f0":  min_frac_below_f0,
-        "tukey_param_combos": tukey_param_combos,
-    }
+    return DffConfig(
+        n_skip=n_skip,
+        t_rel=t_rel,
+        x0_all=x0_all,
+        bounds_all=bounds_all,
+        sigma_all=sigma_all,
+        min_frac_below_f0=min_frac_below_f0,
+        tukey_param_combos=tukey_param_combos,
+    )
 
 
 def dff(
     F: np.ndarray,
-    config: dict,
+    config: DffConfig,
     n_jobs: int = -1,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list]:
     """Fit biexp_bright_v1 and return dFF, F0, noise_sd, params, and logs.
@@ -665,7 +674,7 @@ def dff(
     ----------
     F : (N, T) or (T,) array
         Neuropil-corrected fluorescence (same array passed to set_dff_config).
-    config : dict
+    config : DffConfig
         Output of set_dff_config().  All model and fitting parameters are
         read from config, including tukey_param_combos.
     n_jobs : int
@@ -685,19 +694,13 @@ def dff(
     F2d = np.atleast_2d(np.asarray(F, dtype=np.float64))
     N, T = F2d.shape
 
-    n_skip             = config["n_skip"]
-    t_rel              = config["t_rel"]
-    x0_all             = config["x0_all"]
-    bounds_all         = config["bounds_all"]
-    sigma_all          = config["sigma_all"]
-    # .get() fallbacks support configs built before these keys were added
-    min_frac_below_f0  = float(config.get("min_frac_below_f0", 0.05))
-    tukey_param_combos = tuple(
-        tuple(c) for c in config.get(
-            "tukey_param_combos",
-            ((2, 3), (2, 4), (2, 5), (3, 4), (3, 5)),
-        )
-    )
+    n_skip             = config.n_skip
+    t_rel              = config.t_rel
+    x0_all             = config.x0_all
+    bounds_all         = config.bounds_all
+    sigma_all          = config.sigma_all
+    min_frac_below_f0  = config.min_frac_below_f0
+    tukey_param_combos = config.tukey_param_combos
 
     F_fit = F2d[:, n_skip:]
 

--- a/src/aind_ophys_utils/test_dff_triexp.py
+++ b/src/aind_ophys_utils/test_dff_triexp.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from aind_ophys_utils.dff_triexp import (
+    DffConfig,
     _biexp_bright,
     _boundary_fit_error,
     _is_low_f0,
@@ -222,6 +223,45 @@ class TestDffFlat:
                     "pass1_trigger", "pass1_winner", "pass2_winner", "pass1"):
             assert key in log
         assert log["n_passes"] in (1, 2, 3)
+
+    def test_dff_accepts_legacy_dict(self):
+        """dff() should accept a plain dict and convert it via DffConfig.from_dict."""
+        N, T = 2, 600
+        F = _flat_F(N=N, T=T, baseline=100.0, noise_sd=1.0)
+        config = set_dff_config(F, fs=10.0)
+        # Build a minimal legacy-style dict; omit min_frac_below_f0 and
+        # tukey_param_combos to exercise the from_dict defaults.
+        legacy = {
+            "n_skip":     config.n_skip,
+            "t_rel":      config.t_rel,
+            "x0_all":     config.x0_all,
+            "bounds_all": config.bounds_all,
+            "sigma_all":  config.sigma_all,
+        }
+        dff_out, F0, noise_sd, params, logs = dff(F, legacy, n_jobs=1)
+        assert dff_out.shape == (N, T)
+        assert F0.shape == (N, T)
+        assert len(logs) == N
+
+    def test_from_dict_round_trip(self):
+        """DffConfig.from_dict should accept a full dict including params."""
+        F = _flat_F(N=1, T=300)
+        config = set_dff_config(F, fs=10.0)
+        d = {
+            "n_skip":             config.n_skip,
+            "t_rel":              config.t_rel,
+            "x0_all":             config.x0_all,
+            "bounds_all":         config.bounds_all,
+            "sigma_all":          config.sigma_all,
+            "min_frac_below_f0":  config.min_frac_below_f0,
+            "tukey_param_combos": config.tukey_param_combos,
+            "params":             config.params,
+        }
+        rebuilt = DffConfig.from_dict(d)
+        assert rebuilt.n_skip == config.n_skip
+        assert rebuilt.min_frac_below_f0 == config.min_frac_below_f0
+        assert rebuilt.tukey_param_combos == config.tukey_param_combos
+        assert rebuilt.params == config.params
 
 
 # ---------------------------------------------------------------------------

--- a/src/aind_ophys_utils/test_dff_triexp.py
+++ b/src/aind_ophys_utils/test_dff_triexp.py
@@ -2,6 +2,7 @@
 
 Run with:  pytest test_dff_triexp.py -v
 """
+import json
 import warnings
 
 import numpy as np
@@ -96,6 +97,27 @@ class TestTRelStartsAtSkip:
                 "t_rel must not start near zero — bleaching model must be "
                 "evaluated at the correct physical time (~skip_initial_s)"
             )
+
+
+# ---------------------------------------------------------------------------
+# 2. params dict is JSON-serializable
+# ---------------------------------------------------------------------------
+
+class TestParamsJsonSerializable:
+    def test_default_params(self):
+        F = _flat_F()
+        config = set_dff_config(F, fs=10.0)
+        serialised = json.dumps(config.params)  # must not raise
+        roundtrip = json.loads(serialised)
+        assert roundtrip["fs"] == 10.0
+        assert roundtrip["min_frac_below_f0"] == 0.05
+        assert isinstance(roundtrip["tukey_param_combos"], list)
+
+    def test_custom_combos_serializable(self):
+        F = _flat_F()
+        config = set_dff_config(F, fs=10.0, tukey_param_combos=((2, 3), (3, 5)))
+        roundtrip = json.loads(json.dumps(config.params))
+        assert roundtrip["tukey_param_combos"] == [[2, 3], [3, 5]]
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +271,7 @@ class TestDffFlat:
         F = _flat_F(N=1, T=300)
         config = set_dff_config(F, fs=10.0)
         d = {
+            "params": config.params,
             "n_skip": config.n_skip,
             "t_rel": config.t_rel,
             "x0_all": config.x0_all,
@@ -256,7 +279,6 @@ class TestDffFlat:
             "sigma_all": config.sigma_all,
             "min_frac_below_f0": config.min_frac_below_f0,
             "tukey_param_combos": config.tukey_param_combos,
-            "params": config.params,
         }
         rebuilt = DffConfig(**d)
         assert rebuilt.n_skip == config.n_skip

--- a/src/aind_ophys_utils/test_dff_triexp.py
+++ b/src/aind_ophys_utils/test_dff_triexp.py
@@ -2,7 +2,6 @@
 
 Run with:  pytest test_dff_triexp.py -v
 """
-import json
 import warnings
 
 import numpy as np
@@ -73,18 +72,18 @@ class TestTRelStartsAtSkip:
         F = _flat_F(N=1, T=T)
         config = set_dff_config(F, fs=fs, ts=ts, skip_initial_s=skip)
 
-        assert config["n_skip"] == int(np.searchsorted(ts - ts[0], skip))
-        assert pytest.approx(config["t_rel"][0], abs=1e-9) == skip
-        assert len(config["t_rel"]) == T - config["n_skip"]
+        assert config.n_skip == int(np.searchsorted(ts - ts[0], skip))
+        assert pytest.approx(config.t_rel[0], abs=1e-9) == skip
+        assert len(config.t_rel) == T - config.n_skip
 
     def test_without_ts(self):
         T, fs, skip = 600, 10.0, 5.0
         F = _flat_F(N=1, T=T)
         config = set_dff_config(F, fs=fs, skip_initial_s=skip)
 
-        assert config["n_skip"] == int(skip * fs)
+        assert config.n_skip == int(skip * fs)
         # t_rel[0] = (0 + n_skip) / fs = skip
-        assert pytest.approx(config["t_rel"][0], abs=1e-9) == skip
+        assert pytest.approx(config.t_rel[0], abs=1e-9) == skip
 
     def test_t_rel_never_starts_at_zero(self):
         """Regression: old code started t_rel at 0, not skip_initial_s."""
@@ -92,39 +91,10 @@ class TestTRelStartsAtSkip:
         for use_ts in (True, False):
             ts = np.arange(600) / 10.0 if use_ts else None
             config = set_dff_config(F, fs=10.0, ts=ts, skip_initial_s=5.0)
-            assert config["t_rel"][0] > 1.0, (
+            assert config.t_rel[0] > 1.0, (
                 "t_rel must not start near zero — bleaching model must be "
                 "evaluated at the correct physical time (~skip_initial_s)"
             )
-
-
-# ---------------------------------------------------------------------------
-# 2. params dict is JSON-serializable
-# ---------------------------------------------------------------------------
-
-class TestParamsJsonSerializable:
-    def test_default_params(self):
-        F = _flat_F()
-        config = set_dff_config(F, fs=10.0)
-        serialised = json.dumps(config["params"])  # must not raise
-        roundtrip = json.loads(serialised)
-        assert roundtrip["fs"] == 10.0
-        assert roundtrip["min_frac_below_f0"] == 0.05
-        assert isinstance(roundtrip["tukey_param_combos"], list)
-
-    def test_custom_combos_serializable(self):
-        F = _flat_F()
-        config = set_dff_config(F, fs=10.0, tukey_param_combos=((2, 3), (3, 5)))
-        roundtrip = json.loads(json.dumps(config["params"]))
-        assert roundtrip["tukey_param_combos"] == [[2, 3], [3, 5]]
-
-    def test_params_contains_derived_scalars(self):
-        T, fs, skip = 300, 5.0, 5.0
-        F = _flat_F(N=1, T=T)
-        config = set_dff_config(F, fs=fs, skip_initial_s=skip)
-        p = config["params"]
-        assert p["n_skip"] == int(skip * fs)
-        assert p["t_max"] == pytest.approx(config["t_rel"][-1], rel=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -275,7 +245,7 @@ class TestDffSyntheticBleach:
         )
         _, F0_out, _, _, _ = dff(F, config, n_jobs=1)
 
-        n_skip = config["n_skip"]
+        n_skip = config.n_skip
         F0_fit = F0_out[0, n_skip:].astype(np.float64)
         amplitude = float(F0_true.max() - F0_true.min())
 

--- a/src/aind_ophys_utils/test_dff_triexp.py
+++ b/src/aind_ophys_utils/test_dff_triexp.py
@@ -224,40 +224,41 @@ class TestDffFlat:
             assert key in log
         assert log["n_passes"] in (1, 2, 3)
 
-    def test_dff_accepts_legacy_dict(self):
-        """dff() should accept a plain dict and convert it via DffConfig.from_dict."""
+    def test_dff_accepts_dict(self):
+        """dff() should accept a plain dict and splat it into DffConfig."""
         N, T = 2, 600
         F = _flat_F(N=N, T=T, baseline=100.0, noise_sd=1.0)
         config = set_dff_config(F, fs=10.0)
-        # Build a minimal legacy-style dict; omit min_frac_below_f0 and
-        # tukey_param_combos to exercise the from_dict defaults.
-        legacy = {
-            "n_skip":     config.n_skip,
-            "t_rel":      config.t_rel,
-            "x0_all":     config.x0_all,
+        # Dict must contain every DffConfig field — no fallback defaults.
+        d = {
+            "n_skip": config.n_skip,
+            "t_rel": config.t_rel,
+            "x0_all": config.x0_all,
             "bounds_all": config.bounds_all,
-            "sigma_all":  config.sigma_all,
+            "sigma_all": config.sigma_all,
+            "min_frac_below_f0": config.min_frac_below_f0,
+            "tukey_param_combos": config.tukey_param_combos,
         }
-        dff_out, F0, noise_sd, params, logs = dff(F, legacy, n_jobs=1)
+        dff_out, F0, noise_sd, params, logs = dff(F, d, n_jobs=1)
         assert dff_out.shape == (N, T)
         assert F0.shape == (N, T)
         assert len(logs) == N
 
-    def test_from_dict_round_trip(self):
-        """DffConfig.from_dict should accept a full dict including params."""
+    def test_construct_from_dict_round_trip(self):
+        """DffConfig(**d) reconstructs a dataclass from a full field dict."""
         F = _flat_F(N=1, T=300)
         config = set_dff_config(F, fs=10.0)
         d = {
-            "n_skip":             config.n_skip,
-            "t_rel":              config.t_rel,
-            "x0_all":             config.x0_all,
-            "bounds_all":         config.bounds_all,
-            "sigma_all":          config.sigma_all,
-            "min_frac_below_f0":  config.min_frac_below_f0,
+            "n_skip": config.n_skip,
+            "t_rel": config.t_rel,
+            "x0_all": config.x0_all,
+            "bounds_all": config.bounds_all,
+            "sigma_all": config.sigma_all,
+            "min_frac_below_f0": config.min_frac_below_f0,
             "tukey_param_combos": config.tukey_param_combos,
-            "params":             config.params,
+            "params": config.params,
         }
-        rebuilt = DffConfig.from_dict(d)
+        rebuilt = DffConfig(**d)
         assert rebuilt.n_skip == config.n_skip
         assert rebuilt.min_frac_below_f0 == config.min_frac_below_f0
         assert rebuilt.tukey_param_combos == config.tukey_param_combos


### PR DESCRIPTION
Lints & adds some protection to the main dff() function by turning the unchecked "config" dict into a dataclass with named fields for verification. 

Still allows users to pass in a dict, but it will convert it to the new DffConfig class immediately.