### PR TITLE
add segmentation utils and reduce over mask function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ structures, making the modules easy to integrate into any pipeline.
 | `array_utils` | Array downsampling and subsampling utilities with flexible strategies (mean, max, median, first, last, mid) and optional NaN-skipping. |
 | `video_utils` | H5 video downsampling and VP9 video encoding via imageio-ffmpeg. |
 | `motion_border_utils` | Compute motion borders from frame-shift correction outputs. |
+| `segmentation_utils` | Reduce per-pixel value maps to per-ROI values: a generic `reduce_over_masks` engine (mean/max/median/... under each mask) and a `roi_probabilities` wrapper that turns a Cellpose `cellprob` map into one aggregate probability per ROI. |
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     'matplotlib>=3.9',
     'pandas>=2.2.2',
     'scikit-image>=0.24',
+    'scipy>=1.11',
     'statsmodels>=0.14.2',
     'torch>=2.3'
 ]

--- a/src/aind_ophys_utils/segmentation_utils.py
+++ b/src/aind_ophys_utils/segmentation_utils.py
@@ -1,0 +1,133 @@
+""" Reduce per-pixel value maps to per-mask (per-ROI) values """
+
+import warnings
+from typing import Callable
+
+import numpy as np
+from scipy.special import expit
+
+
+def reduce_over_masks(
+    masks: np.ndarray,
+    values: np.ndarray,
+    reduce_fn: Callable[[np.ndarray], float] = np.mean,
+    threshold: float = 0.0,
+    empty_fill: float = np.nan,
+) -> np.ndarray:
+    """Aggregate a per-pixel value map to one scalar per mask.
+
+    For each mask, gathers the ``values`` pixels that belong to it
+    (``masks[i] > threshold``) and reduces them to a single scalar with
+    ``reduce_fn``. Masks with no member pixels yield ``empty_fill``
+    without invoking ``reduce_fn`` (avoiding empty-slice warnings).
+
+    Parameters
+    ----------
+    masks : numpy.ndarray
+        Mask stack of shape ``(n_masks, height, width)``. A pixel
+        belongs to mask ``i`` when ``masks[i] > threshold``. Values may
+        be boolean masks or floating-point pixel weights (e.g. suite2p
+        ``lam``); only membership is used.
+    values : numpy.ndarray
+        Per-pixel value map of shape ``(height, width)``.
+    reduce_fn : callable
+        Reduction applied to the 1-D array of member-pixel values,
+        returning a scalar. Defaults to ``numpy.mean``. Any function
+        with that signature works (``numpy.max``, ``numpy.median``,
+        ``numpy.sum``, ...).
+    threshold : float
+        A pixel belongs to a mask when its value is strictly greater
+        than this threshold. Defaults to ``0.0``.
+    empty_fill : float
+        Value returned for masks with no member pixels. Defaults to
+        ``numpy.nan``.
+
+    Returns
+    -------
+    numpy.ndarray
+        1-D float array of shape ``(n_masks,)``.
+
+    Raises
+    ------
+    ValueError
+        If ``masks`` is not 3-D, ``values`` is not 2-D, or their
+        spatial dimensions do not match.
+    """
+    if masks.ndim != 3:
+        raise ValueError(
+            "masks must be 3-D (n_masks, height, width); got "
+            f"{masks.ndim}-D."
+        )
+    if values.ndim != 2:
+        raise ValueError(
+            f"values must be 2-D (height, width); got {values.ndim}-D."
+        )
+    if masks.shape[1:] != values.shape:
+        raise ValueError(
+            f"masks spatial shape {masks.shape[1:]} does not match "
+            f"values shape {values.shape}."
+        )
+
+    n_masks = masks.shape[0]
+    out = np.full(n_masks, empty_fill, dtype=float)
+    for i in range(n_masks):
+        members = masks[i] > threshold
+        if members.any():
+            out[i] = reduce_fn(values[members])
+    return out
+
+
+def roi_probabilities(
+    roi_masks: np.ndarray,
+    probability_map: np.ndarray,
+    apply_sigmoid: bool = True,
+    threshold: float = 0.0,
+    empty_fill: float = np.nan,
+) -> np.ndarray:
+    """Mean per-ROI probability from a per-pixel score map.
+
+    Thin wrapper around :func:`reduce_over_masks` for the common case
+    of turning a Cellpose ``cellprob`` map (logit-like scores) into one
+    aggregate probability per ROI: optionally sigmoid-transform, then
+    take the mean under each ROI mask.
+
+    Parameters
+    ----------
+    roi_masks : numpy.ndarray
+        ROI masks of shape ``(n_rois, height, width)``; see
+        :func:`reduce_over_masks`.
+    probability_map : numpy.ndarray
+        Per-pixel map of shape ``(height, width)``. Treated as
+        logit-like scores when ``apply_sigmoid`` is True, otherwise
+        assumed to lie in ``[0, 1]``.
+    apply_sigmoid : bool
+        If True (default), apply ``scipy.special.expit`` before
+        averaging (logit 0 -> 0.5).
+    threshold : float
+        Membership threshold forwarded to :func:`reduce_over_masks`.
+    empty_fill : float
+        Fill value for empty ROIs forwarded to
+        :func:`reduce_over_masks`.
+
+    Returns
+    -------
+    numpy.ndarray
+        1-D float array of shape ``(n_rois,)`` of mean probabilities.
+    """
+    if apply_sigmoid:
+        values = expit(probability_map)
+    else:
+        values = np.asarray(probability_map)
+        if values.size and (values.min() < 0.0 or values.max() > 1.0):
+            warnings.warn(
+                "probability_map has values outside [0, 1] but "
+                "apply_sigmoid is False.",
+                stacklevel=2,
+            )
+    return reduce_over_masks(
+        roi_masks,
+        values,
+        reduce_fn=np.mean,
+        threshold=threshold,
+        empty_fill=empty_fill,
+    )

--- a/tests/test_segmentation_utils.py
+++ b/tests/test_segmentation_utils.py
@@ -1,0 +1,100 @@
+""" Tests for aind_ophys_utils.segmentation_utils """
+
+import numpy as np
+import pytest
+from scipy.special import expit
+
+from aind_ophys_utils.segmentation_utils import (
+    reduce_over_masks,
+    roi_probabilities,
+)
+
+
+def test_reduce_over_masks_default_mean():
+    """Default reduction is the per-mask mean."""
+    values = np.array([[1.0, 3.0], [10.0, 10.0]])
+    masks = np.array([[[1, 1], [0, 0]]], dtype=float)
+    assert np.isclose(reduce_over_masks(masks, values)[0], 2.0)
+
+
+def test_reduce_over_masks_custom_reduce_fn():
+    """A different reduce_fn (max, sum) is honored."""
+    values = np.array([[1.0, 3.0], [10.0, 2.0]])
+    masks = np.array([[[1, 1], [1, 0]]], dtype=float)
+    assert reduce_over_masks(masks, values, np.max)[0] == 10.0
+    assert reduce_over_masks(masks, values, np.sum)[0] == 14.0
+
+
+def test_reduce_over_masks_threshold():
+    """Raising the threshold drops sub-threshold weighted pixels."""
+    values = np.array([[0.0, 1.0]])
+    masks = np.array([[[0.3, 0.9]]], dtype=float)
+    both = reduce_over_masks(masks, values)
+    high = reduce_over_masks(masks, values, threshold=0.5)
+    assert np.isclose(both[0], 0.5)  # mean(0.0, 1.0)
+    assert np.isclose(high[0], 1.0)  # only the 0.9-weight pixel
+
+
+def test_reduce_over_masks_empty_mask_fill():
+    """A mask with no member pixels returns empty_fill."""
+    values = np.zeros((1, 2))
+    masks = np.array([[[0, 0]]], dtype=float)
+    assert np.isnan(reduce_over_masks(masks, values)[0])
+    assert reduce_over_masks(masks, values, empty_fill=-1.0)[0] == -1.0
+
+
+def test_reduce_over_masks_validation():
+    """Shape / dimension mismatches raise ValueError."""
+    values = np.zeros((1, 2))
+    with pytest.raises(ValueError):
+        reduce_over_masks(np.zeros((2, 2)), values)
+    with pytest.raises(ValueError):
+        reduce_over_masks(np.zeros((1, 1, 2)), np.zeros((2, 2, 2)))
+    with pytest.raises(ValueError):
+        reduce_over_masks(np.zeros((1, 1, 2)), np.zeros((3, 3)))
+
+
+def test_roi_probabilities_sigmoid_logit_zero_is_half():
+    """Logit 0 maps to probability 0.5 under each mask."""
+    prob_map = np.zeros((2, 2))
+    masks = np.array(
+        [
+            [[1, 0], [0, 0]],
+            [[0, 1], [1, 1]],
+        ],
+        dtype=float,
+    )
+    result = roi_probabilities(masks, prob_map)
+    assert result.shape == (2,)
+    assert np.allclose(result, [0.5, 0.5])
+
+
+def test_roi_probabilities_matches_manual_sigmoid_mean():
+    """Whole-FOV ROI equals the mean of expit over the map."""
+    logits = np.array([[2.0, -2.0], [0.0, 10.0]])
+    masks = np.ones((1, 2, 2), dtype=float)
+    result = roi_probabilities(masks, logits)
+    assert np.isclose(result[0], expit(logits).mean())
+
+
+def test_roi_probabilities_apply_sigmoid_false():
+    """With apply_sigmoid=False the map is averaged as-is."""
+    prob_map = np.array([[0.2, 0.4], [0.6, 0.8]])
+    masks = np.array([[[1, 0], [0, 1]]], dtype=float)
+    result = roi_probabilities(masks, prob_map, apply_sigmoid=False)
+    assert np.isclose(result[0], 0.5)  # mean(0.2, 0.8)
+
+
+def test_roi_probabilities_warns_out_of_range_without_sigmoid():
+    """Out-of-[0,1] input warns when apply_sigmoid is False."""
+    prob_map = np.array([[5.0, -5.0]])
+    masks = np.ones((1, 1, 2), dtype=float)
+    with pytest.warns(UserWarning):
+        roi_probabilities(masks, prob_map, apply_sigmoid=False)
+
+
+def test_roi_probabilities_empty_mask_fill():
+    """Empty ROI masks propagate the fill value."""
+    prob_map = np.zeros((1, 2))
+    masks = np.array([[[0, 0]]], dtype=float)
+    assert np.isnan(roi_probabilities(masks, prob_map)[0])


### PR DESCRIPTION
To address https://github.com/AllenNeuralDynamics/aind-ophys-nwb/issues/76

This PR adds segmentation_utils.py module and breaks up Virgil's code into a generic `reduce_over_masks` function, and a wrapper that calls it `roi_probabilities`

This will be called by aind-ophys-extraction, when running cellpose, in order to generate a single soma probability per ROI given cellpose_cellprob, which is a pixel-by-pixel probability (`values` in reduce_over_masks`).

`roi_probabilities` takes a mean of the values, after running a sigmoid, based on Virgil's `compute_soma_probs` function.