### PR TITLE
Simplify percentile filter: always use scipy, add skipna

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,4 @@ exclude =
     __pycache__,
     build
 max-complexity = 10
+max-line-length = 100

--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,4 @@ exclude =
     build
 max-complexity = 10
 max-line-length = 100
+extend-ignore = E203

--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -10,10 +10,10 @@ jobs:
     continue-on-error: true
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: 3.8
+        python-version: '3.10'
     - name: Install dependencies
       run: | 
         python -m pip install -e .[dev] --no-cache-dir
@@ -67,10 +67,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Pull latest changes
         run: git pull origin main
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools wheel twine build

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 
 # MacOs
 **/.DS_Store
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -5,15 +5,45 @@
 [![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 ![Interrogate](https://img.shields.io/badge/interrogate-100.0%25-brightgreen)
 ![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen?logo=codecov)
-![Python](https://img.shields.io/badge/python->=3.7-blue?logo=python)
+![Python](https://img.shields.io/badge/python->=3.10-blue?logo=python)
 
-This repository contains python utility methods for processing optical physiology data. Methods in this repository have simple, standard data interfaces and are generally applicable to optical physiology data. As much as possible think arrays and dataframes rather than complex project-specific data structures. 
+Python utility library for processing calcium imaging (optical physiology) data.
+All interfaces are array-based (NumPy / h5py) with no project-specific data
+structures, making the modules easy to integrate into any pipeline.
+
+## Modules
+
+| Module | Description |
+|---|---|
+| `baseline_fitting` | Robust parametric baseline fitting: M-estimator norms (Tukey biweight variants), IRLS nonlinear fitting with JAX autodiff, robust LOWESS smoother, and a high-level `fit_baseline` orchestrator that chains bleach-trend fitting with local fluctuation estimation. |
+| `dff` | ΔF/F computation from fluorescence traces. Inactive-frame masking baseline, parallelised across ROIs, with a `plot_dff` helper for QA visualisation. |
+| `signal_utils` | Signal processing primitives: running percentile filter, nanmedian filter, robust noise standard deviation (MAD / FFT / Welch), and a fast noise estimator using GPU-accelerated FFTs via PyTorch. |
+| `summary_images` | GPU-accelerated summary images for calcium imaging movies: mean, max-correlation (Cn), and peak-to-noise ratio (PNR). |
+| `array_utils` | Array downsampling and subsampling utilities with flexible strategies (mean, max, median, first, last, mid) and optional NaN-skipping. |
+| `video_utils` | H5 video downsampling and VP9 video encoding via imageio-ffmpeg. |
+| `motion_border_utils` | Compute motion borders from frame-shift correction outputs. |
 
 ## Installation
 
 ```bash
 pip install aind-ophys-utils
 ```
+
+> **GPU / CPU note.** `aind-ophys-utils` depends on [PyTorch](https://pytorch.org/),
+> which pulls in CUDA libraries by default from PyPI (~2 GB).  To install a
+> CPU-only build instead, install PyTorch first using the official CPU index, then
+> install this package:
+>
+> ```bash
+> pip install torch --index-url https://download.pytorch.org/whl/cpu
+> pip install aind-ophys-utils
+> ```
+>
+> Alternatively, pass `--extra-index-url` in a single command:
+>
+> ```bash
+> pip install aind-ophys-utils --extra-index-url https://download.pytorch.org/whl/cpu
+> ```
 
 To use the software from source, clone the repository and in the root directory run
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aind-ophys-utils"
 description = "Generated from aind-library-template"
 license = {text = "MIT"}
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 authors = [
     {name = "Allen Institute for Neural Dynamics"}
 ]
@@ -17,11 +17,14 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'h5py',
-    'imageio-ffmpeg',
-    'pandas',
-    'scikit-image',
-    'torch'
+    'h5py>=3.11',
+    'imageio-ffmpeg>=0.5',
+    'jax>=0.4.26',
+    'matplotlib>=3.9',
+    'pandas>=2.2.2',
+    'scikit-image>=0.24',
+    'statsmodels>=0.14.2',
+    'torch>=2.3'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_ophys_utils/__init__.py
+++ b/src/aind_ophys_utils/__init__.py
@@ -1,2 +1,2 @@
 """Init package"""
-__version__ = "0.0.9"
+__version__ = "0.1.0"

--- a/src/aind_ophys_utils/array_utils.py
+++ b/src/aind_ophys_utils/array_utils.py
@@ -4,7 +4,7 @@ import warnings
 from functools import partial
 from itertools import product
 from multiprocessing.pool import Pool, ThreadPool
-from typing import Optional, Union
+
 
 import h5py
 import numpy as np
@@ -111,12 +111,12 @@ _nanmid = partial(_select, which="mid")
 
 
 def subsample_array(
-    array: Union[h5py.Dataset, np.ndarray],
+    array: h5py.Dataset | np.ndarray,
     factors: tuple,
     strategy: str = "first",
     skipna: bool = False,
-    n_jobs: Optional[int] = None,
-    dtype: Optional[type] = None,
+    n_jobs: int | None = None,
+    dtype: type | None = None,
 ) -> np.ndarray:
     """subsamples an array-like object along each axis i by factors[i]
 
@@ -130,9 +130,9 @@ def subsample_array(
         Subsampling strategy. 'first', 'last', 'mid'/'middle'.
     skipna: bool
         Exclude NaN values when computing the result.
-    n_jobs: Optional[int]
+    n_jobs: int | None
         The number of jobs to run in parallel.
-    dtype: Optional[type]
+    dtype: type | None
         The dtype of the returned array. By default, the same as
         the input dtype.
 
@@ -153,11 +153,11 @@ def subsample_array(
 
 
 def _subsample_array(
-    array: Union[h5py.Dataset, np.ndarray],
+    array: h5py.Dataset | np.ndarray,
     factors: tuple,
     strategy: str = "first",
-    n_jobs: Optional[int] = None,
-    dtype: Optional[type] = None,
+    n_jobs: int | None = None,
+    dtype: type | None = None,
 ) -> np.ndarray:
     """subsample w/o skipping nans"""
     T = array.shape[0]
@@ -196,11 +196,11 @@ def _subsample_array(
 
 
 def _subsample_array_nan(
-    array: Union[h5py.Dataset, np.ndarray],
+    array: h5py.Dataset | np.ndarray,
     factors: tuple,
     strategy: str = "first",
-    n_jobs: Optional[int] = None,
-    dtype: Optional[type] = None,
+    n_jobs: int | None = None,
+    dtype: type | None = None,
 ) -> np.ndarray:
     """subsample w/ skipping nans"""
     fun = {"first": _nanfirst, "last": _nanlast, "mid": _nanmid}[strategy]
@@ -246,7 +246,7 @@ def _format_factors(factors, output_fps, input_fps, ndim):
     """
     Auxiliary function to handle different formats of `factors`
 
-    factors : Union[None, int, Tuple[int, ...]]
+    factors : None | int | tuple[int, ...]
         The desired downsampling factors. This can be:
         - None: in which case the factors will be calculated from the
           input and output frame rates.
@@ -274,14 +274,14 @@ def _format_factors(factors, output_fps, input_fps, ndim):
 
 
 def downsample_array(
-    array: Union[h5py.Dataset, np.ndarray],
+    array: h5py.Dataset | np.ndarray,
     input_fps: float = 31.0,
     output_fps: float = 4.0,
-    factors: Union[tuple, int] = None,
+    factors: tuple | int = None,
     strategy: str = "mean",
     skipna: bool = False,
-    n_jobs: Optional[int] = None,
-    dtype: Optional[type] = None,
+    n_jobs: int | None = None,
+    dtype: type | None = None,
 ) -> np.ndarray:
     """Downsamples an array-like object along each axis i by factors[i]
 
@@ -301,9 +301,9 @@ def downsample_array(
         'first', 'last', 'mid'/'middle'.
     skipna: bool
         Exclude NaN values when computing the result.
-    n_jobs: Optional[int]
+    n_jobs: int | None
         The number of jobs to run in parallel.
-    dtype: Optional[type]
+    dtype: type | None
         The dtype of the returned array. By default, the same as
         the input dtype, except for the 'mean' and 'median' strategy.
         In the latter cases, an array of type float32 will be created if
@@ -352,11 +352,11 @@ def downsample_array(
 
 
 def _downsample_array_nan(
-    array: Union[h5py.Dataset, np.ndarray],
+    array: h5py.Dataset | np.ndarray,
     factors: tuple,
     fun: callable,
-    n_jobs: Optional[int] = None,
-    dtype: Optional[type] = None,
+    n_jobs: int | None = None,
+    dtype: type | None = None,
 ) -> np.ndarray:
     """downsample w/ skipping nans"""
     T = array.shape[0]
@@ -395,11 +395,11 @@ def _downsample_array_nan(
 
 
 def _downsample_array(
-    array: Union[h5py.Dataset, np.ndarray],
+    array: h5py.Dataset | np.ndarray,
     factors: tuple,
     fun: callable,
-    n_jobs: Optional[int] = None,
-    dtype: Optional[type] = None,
+    n_jobs: int | None = None,
+    dtype: type | None = None,
     strategy: str = "mean",
 ) -> np.ndarray:
     """downsample w/o skipping nans"""
@@ -483,8 +483,8 @@ def _downsample_array(
 
 def normalize_array(
     array: np.ndarray,
-    lower_cutoff: Optional[float] = None,
-    upper_cutoff: Optional[float] = None,
+    lower_cutoff: float | None = None,
+    upper_cutoff: float | None = None,
     dtype: type = np.uint8,
 ) -> np.ndarray:
     """
@@ -495,10 +495,10 @@ def normalize_array(
     ----------
     array: numpy.ndarray (float)
         array to be normalized
-    lower_cutoff: Optional[float]
+    lower_cutoff: float | None
         threshold, below which will be = dtype.min
         (if None, will be set to array.min())
-    upper_cutoff: Optional[float]
+    upper_cutoff: float | None
         threshold, above which will be = dtype.max
         (if None, will be set to array.max())
     dtype: type

--- a/src/aind_ophys_utils/baseline_fitting.py
+++ b/src/aind_ophys_utils/baseline_fitting.py
@@ -1,0 +1,933 @@
+"""Robust baseline fitting utilities.
+
+Provides M-estimator norms (Tukey biweight variants) and the
+``nonlinear_fit`` IRLS routine used to fit parametric bleach baselines.
+Also exposes a robust LOWESS smoother and a plotting helper.
+"""
+import inspect
+from functools import partial
+from typing import Callable, Literal
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from aind_ophys_utils.signal_utils import percentile_filter
+from scipy.optimize import brentq, OptimizeResult, minimize
+from statsmodels.nonparametric._smoothers_lowess import lowess as _sm_lowess
+from statsmodels.robust import scale
+from statsmodels.robust.norms import RobustNorm
+
+jax.config.update("jax_enable_x64", True)
+
+
+# -----------------------------
+#  Baselines with Jacobians or JAX tracing for autodiff
+# -----------------------------
+def sum_of_exps(
+    params: np.ndarray,
+    t: np.ndarray,
+    xp=np,
+    return_jac: bool = False,
+) -> np.ndarray | jax.Array | tuple[np.ndarray, np.ndarray]:
+    """
+    Baseline as a sum of exponentials, optionally with a constant offset.
+
+    Parameters
+    ----------
+    params : np.ndarray
+        Parameter vector.  Elements are interleaved amplitude/time-constant
+        pairs ``(b_1, tau_1, b_2, tau_2, ...)``.  When the total number of
+        parameters is **odd**, the first element is a constant offset
+        ``b_inf``; the remaining elements are the pairs:
+
+            y = b_inf + b_1*exp(-t/tau_1) + b_2*exp(-t/tau_2) + ...
+
+        When the number of parameters is **even** there is no constant term:
+
+            y = b_1*exp(-t/tau_1) + b_2*exp(-t/tau_2) + ...
+
+        Negative amplitudes are permitted and represent suppression (e.g.
+        a brightening artefact correction).
+
+        Typical special cases by parameter count:
+
+        - 3 params ``[b_inf, b, tau]``                         → single exp
+        - 5 params ``[b_inf, b_1, tau_1, b_2, tau_2]``         → double exp
+        - 9 params ``[b_inf, b_1, tau_1, ..., b_4, tau_4]``    → quad exp
+    t : np.ndarray
+        Timestamps.
+    xp : module, optional
+        Array namespace to use.  Pass ``jnp`` for JAX tracing; default ``np``.
+    return_jac : bool, optional
+        If True, return the analytic Jacobian alongside the model prediction.
+        Ignored when ``xp is jnp``; use autodiff instead.
+
+    Returns
+    -------
+    y : np.ndarray
+        Model prediction.
+    J : np.ndarray, optional
+        Jacobian with respect to ``params``, shape ``(len(t), len(params))``.
+        Returned only when ``return_jac=True``.
+
+    Notes
+    -----
+    **Sign convention for amplitudes.** Negative amplitudes are intentionally
+    permitted — they encode "suppression" terms. A ``+b_i·exp(-t/tau_i)`` with
+    ``b_i <= 0`` is equivalent to a ``-|b_i|·exp(-t/tau_i)`` brightening-suppression
+    term in the older standalone ``bright`` model. The function imposes no sign
+    constraint; callers that need non-negative amplitudes (or non-positive ones for
+    explicit suppression slots) must supply explicit ``bounds`` to the fit harness
+    (e.g. ``nonlinear_fit`` or ``fit_baseline``) — those harnesses do not enforce
+    a sign default.
+    """
+    n = len(params)
+    has_const = n % 2 == 1
+    pair_start = 1 if has_const else 0
+    n_pairs = (n - pair_start) // 2
+
+    y = params[0] if has_const else 0.0
+
+    if return_jac:
+        J = np.empty((t.size, n))
+        if has_const:
+            J[:, 0] = 1.0
+
+    for i in range(n_pairs):
+        b_i = params[pair_start + 2 * i]
+        tau_i = params[pair_start + 2 * i + 1]
+        E_i = xp.exp(-t / tau_i)
+        y = y + b_i * E_i
+        if return_jac:
+            j = pair_start + 2 * i
+            J[:, j] = E_i
+            J[:, j + 1] = b_i / tau_i**2 * (t * E_i)
+
+    if not return_jac:
+        return y
+    return y, J
+
+
+# -----------------------------
+#  M-estimators
+# -----------------------------
+class AsymmetricTukeyBiweight(RobustNorm):
+    """
+    Asymmetric Tukey Biweight norm for robust regression.
+
+    Allows different tuning constants for positive and negative residuals,
+    providing more flexibility in handling asymmetric outliers.
+
+    Parameters
+    ----------
+    c_pos : float, optional
+        Tuning constant for positive residuals, default is 4.685.
+    c_neg : float, optional
+        Tuning constant for negative residuals, default is 4.685.
+    xp : module, optional
+        Array namespace to use. Pass ``jnp`` for JAX tracing, default ``np``.
+    """
+
+    def __init__(self, c_pos: float = 4.685, c_neg: float = 4.685, xp=np):
+        """Validate tuning constants and pre-compute the rho normalization factors."""
+        if c_pos <= 0 or c_neg <= 0:
+            raise ValueError("Tuning constants must be positive")
+        self.c_pos = c_pos
+        self.c_neg = c_neg
+        self.factor_pos = c_pos**2 / 6
+        self.factor_neg = c_neg**2 / 6
+        self.xp = xp
+
+    def _rho_half(self, z, c: float, factor: float):
+        """Tukey rho on one half-line: quadratic for |z|<=c, capped at ``factor``."""
+        if np.isinf(c):  # Python-level scalar check, safe inside JAX traces
+            return 0.5 * z**2
+        t2 = (z / c) ** 2
+        return self.xp.where(t2 <= 1, factor * (1 - (1 - t2) ** 3), factor)
+
+    def rho(self, z):
+        """Asymmetric Tukey rho — branches on the sign of ``z``."""
+        z = self.xp.asarray(z)
+        return self.xp.where(
+            z > 0,
+            self._rho_half(z, self.c_pos, self.factor_pos),
+            self._rho_half(z, self.c_neg, self.factor_neg),
+        )
+
+    def psi(self, z):
+        """Influence function (derivative of rho); zero outside the cutoff."""
+        z = self.xp.asarray(z)
+        c = self.xp.where(z > 0, self.c_pos, self.c_neg).astype(z.dtype)
+        return self.xp.where(self.xp.abs(z) <= c, z * (1 - (z / c) ** 2) ** 2, 0.0)
+
+    def weights(self, z):
+        """IRLS weights — psi(z) / z; zero outside the cutoff."""
+        z = self.xp.asarray(z)
+        c = self.xp.where(z > 0, self.c_pos, self.c_neg).astype(z.dtype)
+        return self.xp.where(self.xp.abs(z) <= c, (1 - (z / c) ** 2) ** 2, 0.0)
+
+    def psi_deriv(self, z):
+        """Derivative of psi; used for Hessian approximations."""
+        z = self.xp.asarray(z)
+        c = self.xp.where(z > 0, self.c_pos, self.c_neg).astype(z.dtype)
+        t2 = (z / c) ** 2
+        return self.xp.where(
+            self.xp.abs(z) <= c, (1 - t2) ** 2 - 4 * t2 * (1 - t2), 0.0
+        )
+
+    def with_xp(self, xp):
+        """Return a copy of this norm bound to a different array namespace (np or jnp)."""
+        return AsymmetricTukeyBiweight(c_pos=self.c_pos, c_neg=self.c_neg, xp=xp)
+
+
+class OneSidedTukeyBiweight(AsymmetricTukeyBiweight):
+    """
+    One-sided Tukey Biweight norm: quadratic loss for negative residuals,
+    Tukey biweight loss for positive residuals.
+
+    Implemented as :class:`AsymmetricTukeyBiweight` with ``c_neg=np.inf``.
+
+    Parameters
+    ----------
+    c : float, optional
+        Tuning constant for positive residuals, default is 4.685.
+    xp : module, optional
+        Array namespace to use. Pass ``jnp`` for JAX tracing, default ``np``.
+    """
+
+    def __init__(self, c: float = 4.685, xp=np):
+        """Initialize as AsymmetricTukeyBiweight with c_neg=inf (no down-weighting below F0)."""
+        super().__init__(c_pos=c, c_neg=np.inf, xp=xp)
+
+
+class TukeyBiweight(AsymmetricTukeyBiweight):
+    """
+    Symmetric Tukey Biweight norm.
+
+    Parameters
+    ----------
+    c : float, optional
+        Tuning constant, default is 4.685.
+    xp : module, optional
+        Array namespace to use. Pass ``jnp`` for JAX tracing, default ``np``.
+    """
+
+    def __init__(self, c: float = 4.685, xp=np):
+        """Initialize as AsymmetricTukeyBiweight with c_pos == c_neg == c."""
+        super().__init__(c_pos=c, c_neg=c, xp=xp)
+
+    def rho(self, z):
+        """Symmetric Tukey rho — single c, no sign branching."""
+        z = self.xp.asarray(z)
+        return self._rho_half(z, self.c_pos, self.factor_pos)
+
+
+# -----------------------------
+#  Fitting Functions
+# -----------------------------
+def nonlinear_fit(  # noqa: C901
+    # --- data / model ---
+    trace: np.ndarray,
+    t: np.ndarray,
+    model: Callable,
+    x0: np.ndarray,
+    bounds: tuple[tuple[float, float], ...] | None = None,
+    # --- robust / IRLS ---
+    M: RobustNorm | None = None,
+    weights: np.ndarray | None = None,
+    fixed_sigma: float | None = None,
+    maxiter: int = 5,
+    tol: float = 1e-3,
+    sigma_anneal_steps: int = 4,
+    # --- optimizer ---
+    optimizer: str = "L-BFGS-B",
+    optimizer_options: dict | None = None,
+    # --- backend ---
+    backend: Literal["numpy", "jax"] = "numpy",
+    dtype=jnp.float64,
+) -> tuple[np.ndarray, OptimizeResult]:
+    """
+    Fit a nonlinear model to a 1-D trace using OLS or robust IRLS.
+
+    Supports two backends:
+
+    - ``"numpy"``: uses analytic Jacobian if ``model`` accepts
+      ``return_jac=True``, otherwise falls back to the optimizer's numerical
+      gradient estimate.
+    - ``"jax"``: differentiates ``model`` automatically via
+      ``jax.value_and_grad``; the ``model`` need not support ``return_jac``.
+
+    Parameters
+    ----------
+    trace : np.ndarray
+        Observed signal, shape ``(N,)``.
+    t : np.ndarray
+        Time vector passed to ``model``, shape ``(N,)``.
+    model : callable
+        ``model(params, t) -> np.ndarray | jax.Array``.
+        For the numpy backend, may optionally support
+        ``model(params, t, return_jac=True) -> (np.ndarray, np.ndarray)``,
+        returning ``(prediction, J)`` where ``J`` has shape ``(N, n_params)``.
+        For the JAX backend, it's wrapped automatically if the model has an
+        xp parameter.
+    x0 : np.ndarray
+        Initial parameter vector, shape ``(n_params,)``.
+    bounds : sequence of (min, max) pairs or None
+        Parameter bounds passed to ``scipy.optimize.minimize``.
+    M : RobustNorm or None
+        M-estimator norm (e.g. ``TukeyBiweight``).
+        ``None`` → ordinary least squares (OLS).
+        Otherwise → iteratively re-weighted least squares (IRLS) using
+        ``M.rho`` for the loss and ``M.psi`` for the gradient.
+        For the JAX backend, it's converted automatically via ``with_xp(jnp)``.
+    weights : np.ndarray or None
+        Per-point weights, shape ``(N,)``, multiplied into the OLS loss only;
+        does not affect the robust IRLS objective. When ``M=None``, this
+        performs weighted OLS. When ``M`` is set, it warm-starts the OLS
+        pre-pass from a prior fit's ``res.weights``. ``None`` → uniform weights.
+    fixed_sigma : float or None
+        Target robust scale estimate. When provided, the IRLS scale is annealed
+        from the data-driven MAD down to ``fixed_sigma`` over the first
+        ``sigma_anneal_steps`` iterations, then held at ``fixed_sigma`` (see the
+        scale-schedule note below). Useful when the scale is known in advance or
+        inherited from a previous fit. ``None`` → plain MAD-reweighted IRLS at
+        every iteration (no fixed target, no annealing).
+
+        Scale schedule across the fit (when ``fixed_sigma`` is given):
+
+        1. OLS pre-pass — unweighted (or ``weights``-weighted) least squares.
+        2. Annealing — over the first ``sigma_anneal_steps`` IRLS iterations the
+           scale follows a geometric ramp from ``max(fixed_sigma, MAD)`` (the
+           MAD of the OLS residuals, floored at the target) down to
+           ``fixed_sigma``. Starting loose and tightening gradually keeps the
+           non-convex M-estimator out of the bad local minimum it falls into
+           when the trend must drop below heavy one-sided activity.
+        3. Remaining IRLS iterations — held at ``fixed_sigma``.
+
+        ``sigma_anneal_steps=1`` collapses steps 2-3 to a single jump
+        (``max(fixed_sigma, MAD)`` then ``fixed_sigma``); ``>=3`` enables the
+        graduated annealing that extends the usable activity range.
+    sigma_anneal_steps : int
+        Number of geometric steps used to anneal the IRLS scale from the MAD of
+        the OLS residuals down to ``fixed_sigma`` (see ``fixed_sigma``). Only
+        used when ``fixed_sigma`` is not None. ``1`` reproduces the legacy
+        single-jump behaviour; the default ``4`` enables graduated annealing.
+        Iterations are run until at least the ramp completes, so set
+        ``maxiter >= sigma_anneal_steps`` for the full schedule.
+    maxiter : int
+        Maximum number of IRLS outer iterations. Ignored when ``M=None``.
+    tol : float
+        IRLS convergence tolerance on the relative parameter change
+        ``‖x_new − x‖ / (‖x‖ + ε)``.
+    optimizer : str
+        Solver passed to ``scipy.optimize.minimize``, default ``"L-BFGS-B"``.
+    optimizer_options : dict or None
+        Options forwarded to ``scipy.optimize.minimize``.
+        Defaults to ``{"maxiter": 20000, "ftol": 1e-12, "gtol": 1e-10}``.
+    backend : {"numpy", "jax"}
+        Numerical backend. ``"jax"`` enables automatic differentiation and
+        JIT compilation; ``"numpy"`` uses model-bundled Jacobians when
+        available.
+    dtype : jax dtype
+        Floating-point precision for the JAX backend, default
+        ``jnp.float64``. Requires ``jax_enable_x64=True``.
+
+    Returns
+    -------
+    fitted : np.ndarray
+        Model prediction at the converged parameters, shape ``(N,)``.
+    res : OptimizeResult
+        Result from the final ``scipy.optimize.minimize`` call, with
+        additional attributes ``res.sigma`` (float, robust scale estimate)
+        and ``res.weights`` (np.ndarray, shape ``(N,)``, M-estimator weights),
+        set only when ``M`` is not ``None``.
+    """
+    if optimizer_options is None:
+        optimizer_options = {"maxiter": 20000, "ftol": 1e-12, "gtol": 1e-10}
+
+    use_jax = backend == "jax"
+    if use_jax:
+        if M is not None:
+            M = M.with_xp(jnp)
+        if "xp" in inspect.signature(model).parameters:
+            model = partial(model, xp=jnp)
+
+    # check once whether model supports return_jac
+    has_return_jac = not use_jax and "return_jac" in inspect.signature(model).parameters
+
+    if use_jax:
+        t_ = jnp.asarray(t, dtype=dtype)
+        y_ = jnp.asarray(trace, dtype=dtype)
+        x = jnp.asarray(x0, dtype=dtype)
+        w_ = jnp.asarray(weights, dtype=dtype) if weights is not None else None
+
+        def _make_obj(loss_and_grad_fn):
+            """Wrap a JAX value-and-grad function as ``(fun, jac)`` callables for scipy.minimize."""
+            cache = {}
+
+            def fun(theta):
+                """Return loss as a Python float and stash the grad for the paired jac callable."""
+                val, grad = loss_and_grad_fn(jnp.asarray(theta, dtype=dtype))
+                cache["g"] = np.array(grad)
+                return float(val)
+
+            return fun, lambda theta: cache["g"]
+
+        def _ols_loss(theta):
+            """OLS loss for the JAX backend; honors per-sample weights when provided."""
+            r = y_ - model(theta, t_)
+            return jnp.sum(w_ * r**2) if w_ is not None else jnp.sum(r**2)
+
+        ols_val_grad = jax.jit(jax.value_and_grad(_ols_loss))
+
+        if M is not None:
+
+            def _robust_loss(theta, sigma):
+                """Robust IRLS loss for the JAX backend at a fixed sigma."""
+                return jnp.sum(M.rho((y_ - model(theta, t_)) / sigma))
+
+            robust_val_grad = jax.jit(jax.value_and_grad(_robust_loss))
+    else:
+        t_ = np.asarray(t)
+        y_ = np.asarray(trace)
+        x = np.asarray(x0, dtype=float).copy()
+        w_ = np.asarray(weights) if weights is not None else None
+
+    # ----------------------------
+    # objective factories
+    # ----------------------------
+    def make_objective_numpy(sigma=None):
+        """Build a scipy.minimize objective for the numpy backend.
+
+        Returns the OLS objective when ``sigma`` is None, the robust IRLS
+        objective at the given ``sigma`` otherwise.
+        """
+        if sigma is None:
+
+            def obj(theta):
+                """OLS objective; returns ``(loss, grad)`` if the model provides a Jacobian."""
+                if has_return_jac:
+                    y_pred, J = model(theta, t_, return_jac=True)
+                    r = y_ - y_pred
+                    if w_ is not None:
+                        return np.sum(w_ * r**2), -2.0 * (J.T @ (w_ * r))
+                    return np.sum(r**2), -2.0 * J.T @ r
+                r = y_ - model(theta, t_)
+                return np.sum(w_ * r**2) if w_ is not None else np.sum(r**2)
+
+        else:
+
+            def obj(theta):
+                """Robust IRLS objective at fixed sigma; emits a Jacobian if the model has one."""
+                if has_return_jac:
+                    y_pred, J = model(theta, t_, return_jac=True)
+                    r = y_ - y_pred
+                    u = r / sigma
+                    return np.sum(M.rho(u)), -(J.T @ M.psi(u)) / sigma
+                r = y_ - model(theta, t_)
+                u = r / sigma
+                return np.sum(M.rho(u))
+
+        return obj
+
+    def make_objective_jax(sigma=None):
+        """Build a scipy.minimize ``(fun, jac)`` pair for the JAX backend at the given sigma."""
+        if sigma is None:
+            return _make_obj(ols_val_grad)
+        else:
+            return _make_obj(lambda theta: robust_val_grad(theta, sigma))
+
+    make_objective = make_objective_jax if use_jax else make_objective_numpy
+    provides_grad = use_jax or has_return_jac
+
+    # ----------------------------
+    # Stage 1 — OLS pre-pass. Always runs; warm-starts the IRLS loop below
+    # (and is the final result when M is None). See the fixed_sigma docstring
+    # for the full OLS → MAD → fixed_sigma scale schedule.
+    # ----------------------------
+    fun_or_pair = make_objective()
+    fun, jac_ = fun_or_pair if use_jax else (fun_or_pair, provides_grad)
+    res = minimize(
+        fun,
+        x,
+        bounds=bounds,
+        method=optimizer,
+        jac=jac_,
+        options=optimizer_options,
+    )
+    x = jnp.asarray(res.x, dtype=dtype) if use_jax else res.x
+
+    # ----------------------------
+    # Stage 2 — sigma anneal schedule (only with a fixed_sigma target).
+    # Geometric ramp from max(fixed_sigma, MAD of OLS residuals) down to
+    # fixed_sigma over sigma_anneal_steps iterations. The MAD is the symmetric,
+    # M-agnostic scale vanilla IRLS would use; flooring at fixed_sigma keeps the
+    # ramp from ever starting tighter than the target. Tightening gradually
+    # (rather than jumping straight to fixed_sigma) keeps the non-convex
+    # M-estimator out of the bad local minimum it hits when the trend must drop
+    # below heavy one-sided activity. Directionality is left to M.
+    # ----------------------------
+    sigma_schedule = None
+    if M is not None and fixed_sigma is not None:
+        resid0 = y_ - model(x, t_)
+        if use_jax:
+            mad0 = jnp.median(jnp.abs(resid0)) * 1.4826
+            mad0 = float(jnp.where(mad0 == 0, jnp.std(resid0), mad0))
+        else:
+            mad0 = scale.mad(resid0, center=0) or float(np.std(resid0))
+        sigma_schedule = np.geomspace(
+            max(fixed_sigma, mad0), fixed_sigma, max(1, sigma_anneal_steps)
+        )
+    n_sched = len(sigma_schedule) if sigma_schedule is not None else 0
+    norm = jnp.linalg.norm if use_jax else np.linalg.norm
+
+    # ----------------------------
+    # Stage 3 — IRLS. Follow the anneal schedule, then hold at fixed_sigma
+    # (or re-estimate the MAD each iteration when no fixed_sigma was given).
+    # Convergence is only allowed to break the loop once the scale has reached
+    # its target, so the ramp is never cut short.
+    # ----------------------------
+    for i in range(max(1, max(maxiter, n_sched)) if M is not None else 0):
+        if fixed_sigma is not None:
+            _sigma = float(sigma_schedule[i]) if i < n_sched else fixed_sigma
+        elif use_jax:
+            resid = y_ - model(x, t_)
+            _sigma = jnp.median(jnp.abs(resid)) * 1.4826
+            _sigma = jnp.where(_sigma == 0, jnp.std(resid), _sigma)
+        else:
+            resid = y_ - model(x, t_)
+            _sigma = scale.mad(resid, center=0) or float(np.std(resid))
+
+        fun_or_pair = make_objective(_sigma)
+        fun, jac_ = fun_or_pair if use_jax else (fun_or_pair, provides_grad)
+        res = minimize(
+            fun,
+            x,
+            bounds=bounds,
+            method=optimizer,
+            jac=jac_,
+            options=optimizer_options,
+        )
+
+        x_new = jnp.asarray(res.x, dtype=dtype) if use_jax else res.x
+        at_target = fixed_sigma is None or float(_sigma) <= fixed_sigma * (1 + 1e-9)
+        if at_target and norm(x_new - x) / (norm(x) + 1e-12) < tol:
+            x = x_new
+            break
+        x = x_new
+
+    fitted = np.array(model(x, t_))
+    if M is not None:
+        res.sigma = float(_sigma)
+        u = (np.array(y_) - fitted) / float(_sigma)
+        res.weights = np.array(M.weights(u))
+    return fitted, res
+
+
+def robust_lowess(
+    # --- data ---
+    y: np.ndarray,
+    t: np.ndarray,
+    # --- smoother ---
+    frac: float = 0.1,
+    # --- robust / IRLS ---
+    M: RobustNorm | None = None,
+    weights: np.ndarray | None = None,
+    fixed_sigma: float | None = None,
+    maxiter: int = 5,
+    tol: float = 1e-3,
+) -> tuple[np.ndarray, np.ndarray, float | None]:
+    """
+    Robust LOWESS smoother with optional outer IRLS loop.
+
+    Parameters
+    ----------
+    y : np.ndarray
+        Raw signal.
+    t : np.ndarray
+        Timestamps (must be sorted).
+    frac : float
+        LOWESS bandwidth as fraction of data length.
+    M : RobustNorm or None
+        If None, single-pass LOWESS. Otherwise, outer IRLS using M.weights.
+        Any M-estimator with a .weights(z) method works, including
+        AsymmetricTukeyBiweight and OneSidedTukeyBiweight.
+    weights : np.ndarray or None
+        Initial point weights, e.g. res.weights from trend fit.
+        Warm-starts the IRLS loop. Defaults to uniform weights.
+    fixed_sigma : float or None
+        Fixed robust scale estimate. When provided, replaces the per-iteration
+        MAD estimate in the IRLS loop. Useful when the scale is known in
+        advance or inherited from a previous fit.
+    maxiter : int
+        Maximum IRLS iterations. Ignored when M is None.
+    tol : float
+        Convergence tolerance on max weight change between iterations.
+
+    Returns
+    -------
+    fluctuation : np.ndarray
+        Smoothed signal.
+    w_current : np.ndarray
+        Final IRLS point weights, shape ``(N,)``.
+        Uniform (all ones) when ``M=None``; otherwise the converged
+        M-estimator weights from the last iteration.
+    sigma : float | None
+        Robust scale estimate.
+    """
+    y = y.astype(np.float64)
+    t = t.astype(np.float64)
+    w_current = (
+        np.asarray(weights, dtype=np.float64)
+        if weights is not None
+        else np.ones(len(y), dtype=np.float64)
+    )
+    delta = 0.01 * (t[-1] - t[0])
+
+    for _ in range(max(1, maxiter) if M is not None else 1):
+        fluctuation = _sm_lowess(
+            y,
+            t,
+            t,
+            resid_weights=w_current,
+            frac=frac,
+            it=0,
+            delta=delta,
+        )[0][:, 1]
+
+        if M is None:
+            sigma = None
+            break
+
+        resid = y - fluctuation
+        if fixed_sigma is not None:
+            sigma = fixed_sigma
+        else:
+            sigma = np.median(np.abs(resid)) * 1.4826
+            if sigma == 0:
+                sigma = np.std(resid)  # pragma: no cover
+
+        w_new = M.weights(resid / sigma)
+        if np.max(np.abs(w_new - w_current)) < tol:
+            break
+        w_current = w_new
+
+    return fluctuation, w_current, sigma
+
+
+def fit_baseline_fluctuations(
+    # --- data ---
+    trace: np.ndarray,
+    t: np.ndarray,
+    trend: np.ndarray | None = None,
+    # --- smoother ---
+    mode: Literal["ratio", "subtract"] = "ratio",
+    window: float = 60.0,
+    method: Literal["lowess", "percentile"] = "lowess",
+    # --- robust / IRLS ---
+    M: RobustNorm | None = None,
+    weights: np.ndarray | None = None,
+    fixed_sigma: float | None = None,
+    maxiter: int = 5,
+    tol: float = 1e-3,
+    # --- percentile ---
+    percentile: float | None = None,
+) -> tuple[np.ndarray, np.ndarray, dict]:
+    """
+    Estimate baseline fluctuations from a fluorescence trace.
+
+    Optionally detrends by a slow trend (e.g. from :func:`nonlinear_fit`),
+    estimates fluctuations via LOWESS or a percentile filter, then retrend
+    to recover the full baseline.
+
+    Parameters
+    ----------
+    trace : np.ndarray
+        Raw fluorescence signal, shape ``(N,)``.
+    t : np.ndarray
+        Timestamps, shape ``(N,)``. Must be sorted in ascending order.
+    trend : np.ndarray or None
+        Slow trend component (e.g. bleaching fit), shape ``(N,)``.
+        If ``None``, no detrending is applied and ``baseline == fluctuation``.
+    mode : {"ratio", "subtract"}
+        How to detrend. ``"ratio"`` divides ``trace`` by ``trend``
+        (use when fluorescence is multiplicatively modulated);
+        ``"subtract"`` subtracts ``trend`` additively.
+    window : float
+        Smoothing window in seconds. Converted to samples internally using
+        the frame rate derived from ``t`` (``fs = 1 / median(diff(t))``),
+        giving ``window_samples = round(window * fs)``. For ``"lowess"``,
+        the sample count is further converted to a fraction of the trace
+        length before being passed to :func:`robust_lowess`. For
+        ``"percentile"``, it is used directly as the filter half-width.
+        Default ``60.0``.
+    method : {"lowess", "percentile"}
+        Smoothing method.
+        ``"lowess"`` — robust locally weighted regression via
+        :func:`robust_lowess`.
+        ``"percentile"`` — sliding percentile filter via
+        :func:`percentile_filter`.
+    M : RobustNorm or None
+        *LOWESS only.* M-estimator with a ``.weights(z)`` method
+        (e.g. :class:`OneSidedTukeyBiweight`). If ``None``, single-pass
+        LOWESS without outer IRLS. Ignored when ``method="percentile"``.
+    weights : np.ndarray or None
+        Per-point weights, shape ``(N,)``. For ``"lowess"``, warm-starts the
+        IRLS loop (e.g. pass ``res.weights`` from :func:`nonlinear_fit`).
+        For ``"percentile"``, used to estimate the baseline percentile when
+        ``percentile=None``.
+    fixed_sigma : float or None
+        Fixed robust scale estimate, **in absolute fluorescence units**.
+        When provided, replaces the per-iteration MAD estimate in the IRLS
+        loop. When ``mode="ratio"``, it is rescaled internally by
+        ``np.nanmedian(trend)`` before being passed to the smoother, so the
+        caller always supplies it in the original signal space. Useful when
+        the scale is known in advance or inherited from a previous fit (e.g.
+        ``res.sigma`` from :func:`nonlinear_fit`).
+    maxiter : int
+        *LOWESS only.* Maximum number of IRLS outer iterations.
+        Ignored when ``M=None`` or ``method="percentile"``.
+    tol : float
+        *LOWESS only.* IRLS convergence tolerance on the maximum absolute
+        weight change between iterations.
+        Ignored when ``M=None`` or ``method="percentile"``.
+    percentile : float or None
+        *Percentile only.* Percentile to track (0–100). If ``None``,
+        estimated from ``weights``: the percentile rank of the
+        weighted mean of ``y`` among its own samples, clipped to ``[5, 50]``.
+        Ignored when ``method="lowess"``.
+
+    Returns
+    -------
+    baseline : np.ndarray
+        Full baseline in the original signal space, shape ``(N,)``.
+        Equal to ``fluctuation`` when ``trend=None``.
+    fluctuation : np.ndarray
+        Detrended baseline estimate, shape ``(N,)``.
+        Ratio relative to ``trend`` when ``mode="ratio"``;
+        additive residual when ``mode="subtract"``.
+    info : dict
+        Diagnostics from the fluctuation fit.
+        ``{"lowess_weights": w, "lowess_sigma": sigma}`` when ``method="lowess"``;
+        ``{"percentile": p, "size": s}`` when ``method="percentile"``.
+        ``lowess_sigma`` is in the detrended signal space: dimensionless
+        (relative to ``trend``) when ``mode="ratio"``, absolute fluorescence
+        units when ``mode="subtract"`` or ``trend=None``.
+    """
+    # detrend — shared
+    _sigma = fixed_sigma
+    if trend is None:
+        y = trace.astype(np.float64)
+    elif mode == "ratio":
+        y = (trace / np.where(trend != 0, trend, np.nan)).astype(np.float64)
+        _sigma = fixed_sigma / np.nanmedian(trend) if fixed_sigma is not None else None
+    else:
+        y = (trace - trend).astype(np.float64)
+
+    # derive window in samples from frame rate
+    fs = 1.0 / np.median(np.diff(t))
+    window_samples = max(1, int(round(window * fs)))
+
+    # dispatch — method-specific, receives y, returns fluctuation
+    if method == "lowess":
+        frac = window_samples / len(y)
+        fluctuation, w, sigma = robust_lowess(
+            y, t, frac, M, weights, _sigma, maxiter, tol
+        )
+        info = {"lowess_weights": w, "lowess_sigma": sigma}
+    elif method == "percentile":
+        size = window_samples
+        if percentile is None:
+            # estimate from weights if available
+            mu_w = (
+                np.average(y, weights=weights) if weights is not None else np.median(y)
+            )
+            percentile = np.clip(np.mean(y <= mu_w) * 100, 5, 50)
+        fluctuation = percentile_filter(y, percentile, size)
+        info = {"percentile": percentile, "size": size}
+    else:
+        raise ValueError(f"Unknown method: {method!r}")
+
+    # retrend — shared
+    if trend is None:
+        return fluctuation, fluctuation, info
+    baseline = trend * fluctuation if mode == "ratio" else trend + fluctuation
+    return baseline, fluctuation, info
+
+
+def fit_baseline(
+    # --- data / model ---
+    trace: np.ndarray,
+    t: np.ndarray,
+    model: Callable,
+    x0: np.ndarray,
+    bounds: tuple[tuple[float, float], ...] | None = None,
+    # --- robust / IRLS ---
+    M: RobustNorm | None = None,
+    M_fluctuations: RobustNorm | None = None,
+    weights: np.ndarray | None = None,
+    fixed_sigma: float | None = None,
+    maxiter: int = 5,
+    tol: float = 1e-3,
+    sigma_anneal_steps: int = 4,
+    sigma_relax_threshold: float = 0.05,
+    # --- smoother ---
+    mode: Literal["ratio", "subtract"] = "ratio",
+    window: float = 60.0,
+    method: Literal["lowess", "percentile"] = "lowess",
+    # --- percentile ---
+    percentile: float | None = None,
+    # --- optimizer ---
+    optimizer: str = "L-BFGS-B",
+    optimizer_options: dict | None = None,
+    # --- backend ---
+    backend: Literal["numpy", "jax"] = "numpy",
+    dtype=jnp.float64,
+) -> tuple[np.ndarray, np.ndarray, OptimizeResult, dict]:
+    """
+    Fit a full fluorescence baseline: slow trend then local fluctuations.
+
+    Combines :func:`nonlinear_fit` (parametric trend) with
+    :func:`fit_baseline_fluctuations` (LOWESS or percentile smoothing) into a
+    single call.
+
+    Parameters
+    ----------
+    trace : np.ndarray
+        Raw fluorescence signal, shape ``(N,)``.
+    t : np.ndarray
+        Timestamps, shape ``(N,)``. Must be sorted in ascending order.
+    model : callable
+        Parametric trend model, e.g. :func:`sum_of_exps`.
+        See :func:`nonlinear_fit` for calling conventions.
+    x0 : np.ndarray
+        Initial parameter vector for ``model``, shape ``(n_params,)``.
+    bounds : sequence of (min, max) pairs or None
+        Parameter bounds passed to ``scipy.optimize.minimize``.
+    M : RobustNorm or None
+        M-estimator for the trend fit (:func:`nonlinear_fit`).
+        ``None`` → OLS.  For ``backend="jax"``, it's converted automatically
+        via ``with_xp(jnp)``.
+        When ``M_fluctuations`` is ``None``, also used for the fluctuation fit.
+    M_fluctuations : RobustNorm or None
+        M-estimator for the fluctuation fit (:func:`fit_baseline_fluctuations`).
+        Falls back to ``M.with_xp(np)`` when ``None``, ensuring NumPy arrays
+        are used in LOWESS regardless of backend.
+    weights : np.ndarray or None
+        Per-point weights, shape ``(N,)``, used to warm-start the OLS
+        pre-pass of the trend fit (passed to :func:`nonlinear_fit`).
+        Typically ``res.weights`` from a previous call. ``None`` → uniform
+        weights. The fluctuation fit always uses the weights produced by
+        the trend fit, not this argument.
+    fixed_sigma : float or None
+        Fixed robust scale estimate, in absolute fluorescence units.
+        Passed to both the trend fit (:func:`nonlinear_fit`) and the
+        fluctuation fit (:func:`fit_baseline_fluctuations`). When provided,
+        replaces the per-iteration MAD estimate in each IRLS loop. Typically
+        ``res.sigma`` from a previous call.
+    maxiter : int
+        Maximum IRLS iterations for both the trend and fluctuation fits.
+    tol : float
+        Convergence tolerance for both IRLS loops.
+    sigma_anneal_steps : int
+        Number of geometric steps used to anneal the trend-fit IRLS scale from
+        the MAD of the OLS residuals down to ``fixed_sigma``. Forwarded to
+        :func:`nonlinear_fit`; see its docstring. Default ``4``.
+    sigma_relax_threshold : float
+        Proportion-of-negative-residuals threshold for triggering a second
+        IRLS attempt with relaxed sigma. Default ``0.05``.
+    mode : {"ratio", "subtract"}
+        How to detrend before estimating fluctuations. ``"ratio"`` divides
+        ``trace`` by the trend (multiplicative); ``"subtract"`` removes it
+        additively.
+    window : float
+        Smoothing window in seconds, passed to
+        :func:`fit_baseline_fluctuations`. Default ``60.0``.
+    method : {"lowess", "percentile"}
+        Fluctuation estimation method.
+    percentile : float or None
+        *Percentile method only.* Percentile to track (0–100). Auto-estimated
+        from ``res.weights`` when ``None``.
+    optimizer : str
+        Solver passed to ``scipy.optimize.minimize``, default ``"L-BFGS-B"``.
+    optimizer_options : dict or None
+        Options forwarded to ``scipy.optimize.minimize``.
+        Defaults to ``{"maxiter": 20000, "ftol": 1e-12, "gtol": 1e-10}``.
+    backend : {"numpy", "jax"}
+        Backend for the trend fit. ``"jax"`` enables autodiff and JIT
+        compilation; ``"numpy"`` uses analytic Jacobians when available.
+    dtype : jax dtype
+        Floating-point precision for the JAX backend, default
+        ``jnp.float64``. Requires ``jax_enable_x64=True``.
+
+    Returns
+    -------
+    F0 : np.ndarray
+        Full baseline in the original signal space, shape ``(N,)``.
+    F0trend : np.ndarray
+        Parametric trend component (output of :func:`nonlinear_fit`),
+        shape ``(N,)``.
+    res : OptimizeResult
+        Result from the final trend optimisation, with additional attributes
+        ``res.sigma`` and ``res.weights`` when ``M`` is not ``None``.
+    info : dict
+        Diagnostics from the fluctuation fit.
+        ``{"lowess_weights": w, "lowess_sigma": sigma}`` when ``method="lowess"``;
+        ``{"percentile": p, "size": s}`` when ``method="percentile"``.
+        ``lowess_sigma`` is in the detrended signal space: dimensionless
+        (relative to ``F0trend``) when ``mode="ratio"``, absolute fluorescence
+        units when ``mode="subtract"``.
+    """
+    if M_fluctuations is None:
+        M_fluctuations = M.with_xp(np) if M is not None else None
+
+    # Pre-compute relaxed sigma for round 2.
+    _relax_sigma = None
+    if M is not None and fixed_sigma is not None:
+        M_np = M.with_xp(np) if backend == "jax" else M
+        if float(min(M_np.weights(2), M_np.weights(-2))) < 0.5:
+            _z_half = brentq(
+                lambda z: float(min(M_np.weights(z), M_np.weights(-z))) - 0.5,
+                0.0, 2.0,
+            )
+            _relax_sigma = fixed_sigma * 2.0 / _z_half
+
+    # Round 1
+    F0trend, res = nonlinear_fit(
+        trace, t, model, x0, bounds, M, weights, fixed_sigma, maxiter, tol,
+        sigma_anneal_steps=sigma_anneal_steps,
+        optimizer=optimizer,
+        optimizer_options=optimizer_options,
+        backend=backend,
+        dtype=dtype,
+    )
+    res.round = 1
+
+    # Round 2 — sigma relaxation if round 1 is degenerate
+    if _relax_sigma is not None and float(np.mean(trace < F0trend)) < sigma_relax_threshold:
+        F0trend, res = nonlinear_fit(
+            trace, t, model, x0, bounds, M, weights, _relax_sigma, maxiter, tol,
+            sigma_anneal_steps=sigma_anneal_steps,
+            optimizer=optimizer,
+            optimizer_options=optimizer_options,
+            backend=backend,
+            dtype=dtype,
+        )
+        res.round = 2
+
+    weights = getattr(res, "weights", None)
+    F0, _, info = fit_baseline_fluctuations(
+        trace,
+        t,
+        F0trend,
+        mode,
+        window,
+        method,
+        M_fluctuations,
+        weights,
+        fixed_sigma,
+        maxiter,
+        tol,
+        percentile,
+    )
+    return F0, F0trend, res, info

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -1,7 +1,7 @@
 """ Utils for computing dF/F """
 from functools import partial
 from multiprocessing.pool import Pool
-from typing import Optional, Tuple, Union
+
 
 import numpy as np
 
@@ -19,8 +19,8 @@ def dff(
     fs: float = 30.0,
     inactive_percentile: int = 10,
     noise_method: str = "mad",
-    n_jobs: Optional[int] = None,
-) -> Tuple[np.ndarray, np.ndarray, Union[np.ndarray, float]]:
+    n_jobs: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray | float]:
     """
     Compute the "delta F over F" from the fluorescence trace(s).
     Uses configurable length median filters to compute baseline for
@@ -48,7 +48,7 @@ def dff(
     noise_method: string
         Method for computing the noise, see ..signal_utils.noise_std
         Choices: 'mad', 'fft', 'welch'
-    n_jobs: Optional[int]
+    n_jobs: int | None
         The number of jobs to run in parallel.
 
     Returns
@@ -93,11 +93,11 @@ def dff(
 
 def _dff_single_trace(
     F: np.ndarray,
-    noise_method: Union[str, float],
+    noise_method: str | float,
     long_filter_length: float,
     short_filter_length: float,
     inactive_percentile: int,
-) -> Tuple[np.ndarray, np.ndarray, float]:
+) -> tuple[np.ndarray, np.ndarray, float]:
     """
     Compute the "delta F over F" from the fluorescence trace.
     Uses configurable length median filters to compute baseline for
@@ -110,7 +110,7 @@ def _dff_single_trace(
     ----------
     F: np.ndarray
         1d numpy array of the neuropil-corrected fluorescence trace.
-    noise_method: Union[str, float]
+    noise_method: str | float
         Method for computing the noise, see ..signal_utils.noise_std.
         Choices: 'mad', 'fft', 'welch'
     long_filter_length: int
@@ -152,3 +152,147 @@ def _dff_single_trace(
     # Calculate dF/F
     dff = (F - baseline) / np.maximum(baseline, noise_sd)
     return dff, baseline, noise_sd
+
+
+def add_zoom_insets(ax_spacer, ax_dff, t, dff_trace, zoom_windows, color):
+    """Attach three zoomed inset axes to *ax_spacer* and mark them on *ax_dff*."""
+    from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
+
+    ax_spacer.axis("off")
+    for j, (start_time, end_time) in enumerate(zoom_windows):
+        inset_ax = inset_axes(
+            ax_spacer,
+            width="100%",
+            height="100%",
+            loc="center",
+            bbox_to_anchor=([0.01, 0.34, 0.67][j], 0.0, 0.32, 0.8),
+            bbox_transform=ax_spacer.transAxes,
+        )
+        mask = (t >= start_time) & (t <= end_time)
+        if np.any(mask):
+            t_zoom, dff_zoom = t[mask], dff_trace[mask] * 100
+            inset_ax.plot(t_zoom, dff_zoom, c=color, lw=0.5)
+            inset_ax.axhline(0, c="k", ls="--")
+            inset_ax.grid(True, alpha=0.8)
+            inset_ax.set_xlim(start_time, end_time)
+            if len(dff_zoom) > 0:
+                mi, ma = np.nanmin(dff_zoom), np.nanmax(dff_zoom)
+                y_margin = 0.1 * (ma - mi)
+                if ~np.isnan(y_margin):
+                    inset_ax.set_ylim(mi - y_margin, ma + y_margin)
+            inset_ax.set_title(
+                f"{['First', 'Middle', 'Last'][j]} {end_time - start_time:.0f}s",
+                fontsize=10,
+                y=0.94,
+            )
+            inset_ax.set_xticks([])
+            inset_ax.set_yticks([])
+            mark_inset(
+                ax_dff, inset_ax, loc1=1, loc2=3,
+                fc="none", ec="#333333", alpha=0.8, linestyle="--", linewidth=1,
+            )
+
+
+def plot_dff(
+    F: np.ndarray,
+    F0: np.ndarray,
+    t: np.ndarray,
+    F0trend: np.ndarray | None = None,
+    zoom_duration: float = 60.0,
+    roi_id=None,
+):
+    """Plot raw fluorescence alongside the fitted baseline(s) and dF/F.
+
+    Works in two modes:
+
+    * **Trend-only** (``F0trend=None``): pass a single baseline as ``F0``.
+      Produces a 2-panel figure (raw signal + dF/F) with optional zoom insets.
+    * **Full baseline** (``F0trend`` provided): pass both the full baseline
+      ``F0`` and the parametric trend ``F0trend`` (e.g. from
+      :func:`~aind_ophys_utils.baseline_fitting.fit_baseline`).
+      Produces a 4-panel figure showing the trend-only and full dF/F
+      separately, each with optional zoom insets.
+
+    Parameters
+    ----------
+    F : np.ndarray
+        Raw fluorescence trace, shape ``(N,)``.
+    F0 : np.ndarray
+        Fitted baseline, shape ``(N,)``.
+    t : np.ndarray
+        Timestamps, shape ``(N,)``.  Pass ``np.arange(len(F)) / frame_rate``
+        to use seconds; ``zoom_duration`` must be in the same units.
+    F0trend : np.ndarray or None
+        Parametric trend component, shape ``(N,)``. When provided, an
+        extra panel showing the fluctuation residuals is added and both
+        trend-only and full dF/F are plotted.
+    zoom_duration : float or None
+        Duration (same units as ``t``) for each zoomed inset window.
+        Pass ``None`` or ``0`` to disable insets.
+    roi_id : int or str or None
+        Region-of-interest identifier added to the figure title.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The figure object.
+    """
+    import matplotlib.pyplot as plt
+
+    has_fluctuations = F0trend is not None
+    show_insets = bool(zoom_duration) and zoom_duration > 0
+
+    # layout: [raw, (fluctuations), (spacer), dff, ...] repeated for each dff trace
+    n_rows = (6 if show_insets else 4) if has_fluctuations else (3 if show_insets else 2)
+    fig, ax = plt.subplots(n_rows, 1, figsize=(15, n_rows * 1.2), sharex=True)
+
+    # panel 0: raw signal + baseline(s)
+    ax[0].plot(t, F, label="$F$")
+    if has_fluctuations:
+        ax[0].plot(t, F0trend, label="$F0_{trend}$")
+    ax[0].plot(t, F0, label="$F0$")
+    ax[0].set_ylabel("$F$ [a.u.]")
+    ax[0].legend(loc=1)
+
+    # panel 1: fluctuations (full-baseline mode only)
+    if has_fluctuations:
+        ax[1].plot(t, F - F0trend, c="C1", label="$F-F0_{trend}$")
+        ax[1].axhline(0, ls="--", c="k")
+        ax[1].plot(t, F0 - F0trend, c="C2", label="$F0_{fluctuations}$")
+        ax[1].set_ylabel("$\\Delta F$ [a.u.]")
+        ax[1].legend(loc=1)
+
+    # dF/F panels: one per baseline when has_fluctuations, otherwise just F0
+    dff_traces = (
+        [(F / F0trend - 1, "C1", "$\\frac{\\Delta F_{trend}}{F0_{trend}}$"),
+         (F / F0 - 1,      "C2", "$\\frac{\\Delta F}{F}$")]
+        if has_fluctuations
+        else [(F / F0 - 1, "C1", "$\\frac{\\Delta F}{F0}$")]
+    )
+    # row layout per trace: [spacer, dff_panel] when insets, else [dff_panel]
+    first_dff_row = 2 if has_fluctuations else 1
+    zoom_windows = None
+    if show_insets:
+        t_total = t[-1] - t[0]
+        zoom_windows = [
+            (t[0], t[0] + zoom_duration),
+            (t[0] + (t_total - zoom_duration) / 2, t[0] + (t_total + zoom_duration) / 2),
+            (max(t[-1] - zoom_duration, t[0]), t[-1]),
+        ]
+
+    for i, (dff_trace, color, label) in enumerate(dff_traces):
+        spacer_row = first_dff_row + i * (2 if show_insets else 1)
+        dff_row = spacer_row + (1 if show_insets else 0)
+        ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label)
+        ax[dff_row].axhline(0, ls="--", c="k")
+        ax[dff_row].set_ylabel(r"$\Delta$F/F [%]")
+        ax[dff_row].legend(loc=1)
+        if show_insets:
+            add_zoom_insets(ax[spacer_row], ax[dff_row], t, dff_trace, zoom_windows, color)
+
+    ax[-1].set_xlim(-0.01 * t[-1], 1.01 * t[-1])
+    ax[-1].set_xlabel("Time [s]")
+    if roi_id is not None:
+        ax[0].set_title(f"cell_roi_id: {int(roi_id)}")
+    plt.subplots_adjust(hspace=0.1, top=0.935, bottom=0.13, left=0.06, right=0.995)
+    return fig

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -1,11 +1,12 @@
-""" Utils for computing dF/F """
+"""Utils for computing dF/F"""
+
 from functools import partial
 from multiprocessing.pool import Pool
-
 
 import numpy as np
 
 from aind_ophys_utils.signal_utils import (
+    fill_nan,
     median_filter,
     noise_std,
     percentile_filter,
@@ -149,6 +150,8 @@ def _dff_single_trace(
     negative_mask = F < (low_baseline - 3 * noise_sd)
     inactive_trace[active_mask + negative_mask] = np.nan
     baseline = median_filter(inactive_trace, long_filter_length, skipna=True)
+    if np.isnan(baseline).any():
+        baseline = fill_nan(baseline)
     # Calculate dF/F
     dff = (F - baseline) / np.maximum(baseline, noise_sd)
     return dff, baseline, noise_sd
@@ -188,8 +191,15 @@ def add_zoom_insets(ax_spacer, ax_dff, t, dff_trace, zoom_windows, color):
             inset_ax.set_xticks([])
             inset_ax.set_yticks([])
             mark_inset(
-                ax_dff, inset_ax, loc1=1, loc2=3,
-                fc="none", ec="#333333", alpha=0.8, linestyle="--", linewidth=1,
+                ax_dff,
+                inset_ax,
+                loc1=1,
+                loc2=3,
+                fc="none",
+                ec="#333333",
+                alpha=0.8,
+                linestyle="--",
+                linewidth=1,
             )
 
 
@@ -243,7 +253,11 @@ def plot_dff(
     show_insets = bool(zoom_duration) and zoom_duration > 0
 
     # layout: [raw, (fluctuations), (spacer), dff, ...] repeated for each dff trace
-    n_rows = (6 if show_insets else 4) if has_fluctuations else (3 if show_insets else 2)
+    n_rows = (
+        (6 if show_insets else 4)
+        if has_fluctuations
+        else (3 if show_insets else 2)
+    )
     fig, ax = plt.subplots(n_rows, 1, figsize=(15, n_rows * 1.2), sharex=True)
 
     # panel 0: raw signal + baseline(s)
@@ -264,8 +278,10 @@ def plot_dff(
 
     # dF/F panels: one per baseline when has_fluctuations, otherwise just F0
     dff_traces = (
-        [(F / F0trend - 1, "C1", "$\\frac{\\Delta F_{trend}}{F0_{trend}}$"),
-         (F / F0 - 1,      "C2", "$\\frac{\\Delta F}{F}$")]
+        [
+            (F / F0trend - 1, "C1", "$\\frac{\\Delta F_{trend}}{F0_{trend}}$"),
+            (F / F0 - 1, "C2", "$\\frac{\\Delta F}{F}$"),
+        ]
         if has_fluctuations
         else [(F / F0 - 1, "C1", "$\\frac{\\Delta F}{F0}$")]
     )
@@ -276,7 +292,10 @@ def plot_dff(
         t_total = t[-1] - t[0]
         zoom_windows = [
             (t[0], t[0] + zoom_duration),
-            (t[0] + (t_total - zoom_duration) / 2, t[0] + (t_total + zoom_duration) / 2),
+            (
+                t[0] + (t_total - zoom_duration) / 2,
+                t[0] + (t_total + zoom_duration) / 2,
+            ),
             (max(t[-1] - zoom_duration, t[0]), t[-1]),
         ]
 
@@ -288,11 +307,15 @@ def plot_dff(
         ax[dff_row].set_ylabel(r"$\Delta$F/F [%]")
         ax[dff_row].legend(loc=1)
         if show_insets:
-            add_zoom_insets(ax[spacer_row], ax[dff_row], t, dff_trace, zoom_windows, color)
+            add_zoom_insets(
+                ax[spacer_row], ax[dff_row], t, dff_trace, zoom_windows, color
+            )
 
     ax[-1].set_xlim(-0.01 * t[-1], 1.01 * t[-1])
     ax[-1].set_xlabel("Time [s]")
     if roi_id is not None:
         ax[0].set_title(f"cell_roi_id: {int(roi_id)}")
-    plt.subplots_adjust(hspace=0.1, top=0.935, bottom=0.13, left=0.06, right=0.995)
+    plt.subplots_adjust(
+        hspace=0.1, top=0.935, bottom=0.13, left=0.06, right=0.995
+    )
     return fig

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -6,7 +6,7 @@ from multiprocessing.pool import Pool
 import numpy as np
 
 from aind_ophys_utils.signal_utils import (
-    nanmedian_filter,
+    median_filter,
     noise_std,
     percentile_filter,
 )
@@ -148,7 +148,7 @@ def _dff_single_trace(
     active_mask = F > (low_baseline + 3 * noise_sd)
     negative_mask = F < (low_baseline - 3 * noise_sd)
     inactive_trace[active_mask + negative_mask] = np.nan
-    baseline = nanmedian_filter(inactive_trace, long_filter_length)
+    baseline = median_filter(inactive_trace, long_filter_length, skipna=True)
     # Calculate dF/F
     dff = (F - baseline) / np.maximum(baseline, noise_sd)
     return dff, baseline, noise_sd

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -6,6 +6,7 @@ from multiprocessing.pool import Pool, ThreadPool
 import numpy as np
 import pandas as pd
 import scipy
+import scipy.ndimage
 import torch
 from scipy import signal
 
@@ -17,9 +18,11 @@ def percentile_filter(
     dtype: type | None = None,
 ) -> np.ndarray:
     """
-    Fast 1D running percentile filter using reflection
-    to extend the input array beyond its boundaries.
-    Uses pandas if input and filter size are long, scipy if short.
+    Fast 1D running percentile filter with reflect boundary handling.
+
+    Uses :func:`scipy.ndimage.percentile_filter` which has O(log n) complexity
+    since scipy 1.15.0 and is faster than the pandas rolling quantile approach
+    across all input sizes and window sizes.
 
     Parameters
     ----------
@@ -41,28 +44,10 @@ def percentile_filter(
     if dtype is None:
         dtype = input.dtype
     if size > len(input):
-        return (np.percentile(input, percentile) * np.ones_like(input)).astype(
-            dtype
-        )
-    if size > 20 and len(input) > 200:
-        return (
-            pd.Series(
-                np.concatenate(
-                    (
-                        input[: size // 2][::-1],
-                        input,
-                        input[: -size // 2 - 1: -1],
-                    )
-                )
-            )
-            .rolling(size, center=True)
-            .quantile(percentile / 100)
-            .to_numpy(dtype)[size // 2: -size // 2]
-        )
-    else:
-        return scipy.ndimage.percentile_filter(
-            input, percentile, size, output=dtype
-        )
+        return (np.percentile(input, percentile) * np.ones_like(input)).astype(dtype)
+    return scipy.ndimage.percentile_filter(
+        input, percentile, size, output=dtype, mode="reflect"
+    )
 
 
 def median_filter(

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -45,9 +45,7 @@ def percentile_filter(
         dtype = input.dtype
     if size > len(input):
         return (np.percentile(input, percentile) * np.ones_like(input)).astype(dtype)
-    return scipy.ndimage.percentile_filter(
-        input, percentile, size, output=dtype, mode="reflect"
-    )
+    return scipy.ndimage.percentile_filter(input, percentile, size, output=dtype)
 
 
 def median_filter(

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -1,6 +1,7 @@
 """ Utils for signal processing """
-from multiprocessing.pool import ThreadPool
-from typing import Optional, Tuple, Union
+
+from multiprocessing.pool import Pool, ThreadPool
+
 
 import numpy as np
 import pandas as pd
@@ -13,7 +14,7 @@ def percentile_filter(
     input: np.ndarray,
     percentile: float,
     size: int,
-    dtype: Optional[type] = None,
+    dtype: type | None = None,
 ) -> np.ndarray:
     """
     Fast 1D running percentile filter using reflection
@@ -28,7 +29,7 @@ def percentile_filter(
         The percentile parameter. Must be between 0 and 100 inclusive.
     size: int
         Length of the median filter to compute a rolling baseline.
-    dtype: Optional[type]
+    dtype: type | None
         The dtype of the returned array. By default an array of
         the same dtype as input will be created.
 
@@ -65,7 +66,7 @@ def percentile_filter(
 
 
 def median_filter(
-    input: np.ndarray, size: int, dtype: Optional[type] = None
+    input: np.ndarray, size: int, dtype: type | None = None
 ) -> np.ndarray:
     """
     Fast 1D median filtering using reflection to
@@ -78,7 +79,7 @@ def median_filter(
         The input array.
     size: int
         Length of the median filter to compute a rolling baseline.
-    dtype: Optional[type]
+    dtype: type | None
         The dtype of the returned array. By default an array of
         the same dtype as input will be created.
 
@@ -90,7 +91,7 @@ def median_filter(
 
 
 def nanmedian_filter(
-    input: np.ndarray, size: int, dtype: Optional[type] = None
+    input: np.ndarray, size: int, dtype: type | None = None
 ) -> np.array:
     """1D median filtering with nan values
 
@@ -149,7 +150,7 @@ def _fill_nan(input: np.ndarray) -> np.ndarray:
     return output
 
 
-def robust_std(x: np.ndarray, axis: int = -1) -> Union[float, np.ndarray]:
+def robust_std(x: np.ndarray, axis: int = -1) -> float | np.ndarray:
     """
     Compute the appropriately scaled median absolute deviation
     assuming normally distributed data. This is a robust statistic.
@@ -175,16 +176,159 @@ def robust_std(x: np.ndarray, axis: int = -1) -> Union[float, np.ndarray]:
     return 1.4826 * mad
 
 
+def _nanwelch_1d_array(
+    data_1d: np.ndarray,
+    fs: float,
+    nperseg: int,
+    noverlap: int,
+    nfft: int,
+    detrend: str,
+    return_onesided: bool,
+    scaling: str,
+    axis: int,
+    max_num_samples: int,
+) -> np.ndarray:
+    """Helper function computing nanwelch on 1D arrays."""
+    data_1d = data_1d[~np.isnan(data_1d)]
+    T = len(data_1d)
+    if T > max_num_samples:
+        data_1d = np.concatenate(
+            (
+                data_1d[: max_num_samples // 3],
+                data_1d[
+                    int(T // 2 - max_num_samples / 6): int(
+                        T // 2 + max_num_samples / 6
+                    )
+                ],
+                data_1d[-max_num_samples // 3:],
+            ),
+        )
+    if T < nperseg:  # return NaN if not enough non-NaN values
+        data_1d = np.nan * np.ones(nperseg)
+    f, Pxx = signal.welch(
+        data_1d,
+        fs=fs,
+        nperseg=nperseg,
+        noverlap=noverlap,
+        nfft=nfft,
+        detrend=detrend,
+        return_onesided=return_onesided,
+        scaling=scaling,
+        axis=axis,
+    )
+    return f, Pxx
+
+
+def _nanwelch_wrapper(args):
+    """Helper function to call nanwelch with unpacked arguments."""
+    return nanwelch(*args)
+
+
+def nanwelch(
+    data: np.ndarray,
+    fs: float = 1.0,
+    nperseg: int | None = None,
+    noverlap: int | None = None,
+    nfft: int | None = None,
+    detrend: str = "constant",
+    return_onesided: bool = True,
+    scaling: str = "density",
+    axis: int = -1,
+    max_num_samples: int = 3072,
+    n_jobs: int | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Apply Welch's method to data of arbitrary dimensions, excluding NaNs.
+
+    Parameters
+    ----------
+    data : ndarray
+        Input data, can be of any dimension.
+    fs : float
+        Sampling frequency of the data.
+    nperseg : int
+        Length of each segment.
+    noverlap : int
+        Number of points to overlap between segments.
+    nfft : int
+        Length of the FFT used.
+    detrend : str or function
+        Specifies how to detrend each segment.
+    return_onesided : bool
+        If True, return a one-sided spectrum for real data.
+    scaling : str
+        Selects between computing the power spectral density
+        ('density') and the power spectrum ('spectrum').
+    axis : int
+        Axis along which the periodogram is computed.
+    max_num_samples: int
+        Number of samples used for computing the noise
+    n_jobs: int | None
+        The number of jobs to run in parallel.
+
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    Pxx : ndarray
+        Power spectral density or power spectrum of data.
+    """
+    if nperseg is None:  # same default as scipy.signal.welch
+        nperseg = 256
+    data = np.moveaxis(data, axis, -1)
+    # Base case: if data is 1D, apply Welch's method directly
+    if data.ndim == 1:
+        return _nanwelch_1d_array(
+            data,
+            fs,
+            nperseg,
+            noverlap,
+            nfft,
+            detrend,
+            return_onesided,
+            scaling,
+            -1,
+            max_num_samples,
+        )
+    # Recursive case: if data is 2D or higher,
+    # apply the function to each sub-array in parallel
+    args = (
+        (
+            sub_array,
+            fs,
+            nperseg,
+            noverlap,
+            nfft,
+            detrend,
+            return_onesided,
+            scaling,
+            -1,
+            max_num_samples,
+            1,
+        )
+        for sub_array in data
+    )
+    # it's usually faster to use only 1 job for "small" data
+    if n_jobs == 1 or (n_jobs is None and np.prod(data.shape[:-1]) <= 5000):
+        results = list(map(_nanwelch_wrapper, args))
+    else:
+        with Pool(n_jobs) as pool:
+            results = list(pool.imap(_nanwelch_wrapper, args))
+    f, Pxx = zip(*results)
+    return f[0], np.array(Pxx)
+
+
 def noise_std(
     x: np.ndarray,
     method: str = "welch",
     max_num_samples: int = 3072,
-    noise_range: Tuple[float, float] = (0.25, 0.5),
+    noise_range: tuple[float, float] = (0.25, 0.5),
     filter_length: int = 31,
     axis: int = -1,
-    n_jobs: Optional[int] = None,
+    n_jobs: int | None = None,
     device: str = "cuda" if torch.cuda.is_available() else "cpu",
-) -> Union[float, np.ndarray]:
+    skipna: bool = False,
+) -> float | np.ndarray:
     """Estimate the standard deviation of the noise in input(s) `x`.
 
     Parameters
@@ -213,20 +357,25 @@ def noise_std(
     axis: int
         Axis along which the noise is computed.
         The default is over the last axis (i.e. ``axis=-1``).
-    n_jobs: Optional[int]
+    n_jobs: int | None
         The number of jobs to run in parallel.
     device: str, default is 'cuda' if GPU is available.
         Device to use when using FFT method; 'cuda' or 'cpu'.
+    skipna: bool
+        Exclude NaN values when computing the result.
 
     Returns
     -------
     noise: float or ndarray
         A robust estimation of the standard deviation of the noise.
     """
-    if x.ndim > 1:
-        if axis != -1:
-            x = np.moveaxis(x, axis, -1)
+    if x.ndim > 1 and axis != -1:
+        x = np.moveaxis(x, axis, -1)
     if method == "mad":
+        if skipna:
+            raise ValueError(  # pragma: no cover
+                "Excluding NaNs (skipna=True) isn't supported for method 'mad'"
+            )
         if x.ndim > 1:
             dims, T = x.shape[:-1], x.shape[-1]
             if n_jobs == 1:
@@ -257,27 +406,44 @@ def noise_std(
             return robust_std(filtered_noise_1)
     else:
         T = x.shape[-1]
-        if T > max_num_samples:
+        if T > max_num_samples and not skipna:
             x = np.concatenate(
                 (
                     x[..., : max_num_samples // 3],
-                    x[..., int(T // 2 - max_num_samples / 6):
-                      int(T // 2 + max_num_samples / 6)],
+                    x[
+                        ...,
+                        int(T // 2 - max_num_samples / 6): int(
+                            T // 2 + max_num_samples / 6
+                        ),
+                    ],
                     x[..., -max_num_samples // 3:],
                 ),
                 axis=-1,
             )
             T = x.shape[-1]
         if method == "welch":
-            if n_jobs == 1 or x.ndim == 1:
-                ff, psd = signal.welch(x)
+            if n_jobs == 1 or x.ndim == 1 or skipna:
+                ff, psd = (
+                    nanwelch(x, max_num_samples=max_num_samples, n_jobs=n_jobs)
+                    if skipna
+                    else signal.welch(x)
+                )
             else:
                 res = ThreadPool(n_jobs).map(signal.welch, x)
                 ff = res[0][0]
                 psd = np.array([r[1] for r in res])
-            psd = torch.tensor(
-                psd[..., (ff >= noise_range[0]) & (ff <= noise_range[1])]) / 2
+            psd = (
+                torch.tensor(
+                    psd[..., (ff >= noise_range[0]) & (ff <= noise_range[1])]
+                )
+                / 2
+            )
         else:
+            if skipna:
+                raise ValueError(  # pragma: no cover
+                    "Excluding NaNs (skipna=True) is not yet supported "
+                    "for method 'fft'"
+                )
             x_torch = torch.tensor(x.astype(np.float32), device=device)
             xdft = torch.fft.rfft(x_torch, axis=-1)
             xdft = xdft[

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -22,7 +22,8 @@ def percentile_filter(
 
     Uses :func:`scipy.ndimage.percentile_filter` which has O(log n) complexity
     since scipy 1.15.0 and is faster than the pandas rolling quantile approach
-    across all input sizes and window sizes.
+    across all input sizes and window sizes. Falls back to pandas rolling
+    quantile when the input contains NaN values.
 
     Parameters
     ----------
@@ -44,7 +45,15 @@ def percentile_filter(
     if dtype is None:
         dtype = input.dtype
     if size > len(input):
-        return (np.percentile(input, percentile) * np.ones_like(input)).astype(dtype)
+        return (np.nanpercentile(input, percentile) * np.ones_like(input)).astype(dtype)
+    if np.isnan(input).any():
+        padded = np.concatenate((input[:size // 2][::-1], input, input[:-size // 2 - 1:-1]))
+        return (
+            pd.Series(padded)
+            .rolling(size, center=True, min_periods=1)
+            .quantile(percentile / 100)
+            .to_numpy(dtype)[size // 2: -size // 2]
+        )
     return scipy.ndimage.percentile_filter(input, percentile, size, output=dtype)
 
 

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -16,14 +16,14 @@ def percentile_filter(
     percentile: float,
     size: int,
     dtype: type | None = None,
+    skipna: bool = False,
 ) -> np.ndarray:
     """
     Fast 1D running percentile filter with reflect boundary handling.
 
     Uses :func:`scipy.ndimage.percentile_filter` which has O(log n) complexity
-    since scipy 1.15.0 and is faster than the pandas rolling quantile approach
-    across all input sizes and window sizes. Falls back to pandas rolling
-    quantile when the input contains NaN values.
+    since scipy 1.15.0. When ``skipna=True``, falls back to a pandas rolling
+    quantile which ignores NaN values within each window.
 
     Parameters
     ----------
@@ -36,6 +36,9 @@ def percentile_filter(
     dtype: type | None
         The dtype of the returned array. By default an array of
         the same dtype as input will be created.
+    skipna: bool
+        If True, NaN values are ignored within each window. If False (default),
+        NaNs propagate to the output.
 
     Returns
     -------
@@ -45,8 +48,9 @@ def percentile_filter(
     if dtype is None:
         dtype = input.dtype
     if size > len(input):
-        return (np.nanpercentile(input, percentile) * np.ones_like(input)).astype(dtype)
-    if np.isnan(input).any():
+        fn = np.nanpercentile if skipna else np.percentile
+        return (fn(input, percentile) * np.ones_like(input)).astype(dtype)
+    if skipna:
         padded = np.concatenate((input[:size // 2][::-1], input, input[:-size // 2 - 1:-1]))
         return (
             pd.Series(padded)
@@ -58,12 +62,13 @@ def percentile_filter(
 
 
 def median_filter(
-    input: np.ndarray, size: int, dtype: type | None = None
+    input: np.ndarray,
+    size: int,
+    dtype: type | None = None,
+    skipna: bool = False,
 ) -> np.ndarray:
     """
-    Fast 1D median filtering using reflection to
-    extend the input array beyond its boundaries.
-    Uses pandas if input and filter size are long, scipy if short.
+    Fast 1D median filtering with reflect boundary handling.
 
     Parameters
     ----------
@@ -74,18 +79,23 @@ def median_filter(
     dtype: type | None
         The dtype of the returned array. By default an array of
         the same dtype as input will be created.
+    skipna: bool
+        If True, NaN values are ignored within each window.
 
     Returns
     -------
     filtered_trace: ndarray
     """
-    return percentile_filter(input, 50, size, dtype)
+    return percentile_filter(input, 50, size, dtype, skipna=skipna)
 
 
 def nanmedian_filter(
     input: np.ndarray, size: int, dtype: type | None = None
 ) -> np.array:
     """1D median filtering with nan values
+
+    .. deprecated::
+        Use :func:`median_filter` with ``skipna=True`` instead.
 
     Parameters
     ----------

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -1,7 +1,7 @@
-""" Utils for signal processing """
+"""Utils for signal processing"""
 
+import warnings
 from multiprocessing.pool import Pool, ThreadPool
-
 
 import numpy as np
 import pandas as pd
@@ -51,14 +51,18 @@ def percentile_filter(
         fn = np.nanpercentile if skipna else np.percentile
         return (fn(input, percentile) * np.ones_like(input)).astype(dtype)
     if skipna:
-        padded = np.concatenate((input[:size // 2][::-1], input, input[:-size // 2 - 1:-1]))
+        padded = np.concatenate(
+            (input[: size // 2][::-1], input, input[: -size // 2 - 1 : -1])
+        )
         return (
             pd.Series(padded)
             .rolling(size, center=True, min_periods=1)
             .quantile(percentile / 100)
-            .to_numpy(dtype)[size // 2: -size // 2]
+            .to_numpy(dtype)[size // 2 : -size // 2]
         )
-    return scipy.ndimage.percentile_filter(input, percentile, size, output=dtype)
+    return scipy.ndimage.percentile_filter(
+        input, percentile, size, output=dtype
+    )
 
 
 def median_filter(
@@ -96,6 +100,7 @@ def nanmedian_filter(
 
     .. deprecated::
         Use :func:`median_filter` with ``skipna=True`` instead.
+        Will be removed in a future release.
 
     Parameters
     ----------
@@ -111,24 +116,29 @@ def nanmedian_filter(
     -------
     filtered_trace: ndarray
     """
+    warnings.warn(
+        "nanmedian_filter is deprecated; use median_filter(..., skipna=True) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     filtered_trace = (
         pd.Series(
             np.concatenate(
-                (input[: size // 2][::-1], input, input[: -size // 2 - 1: -1])
+                (input[: size // 2][::-1], input, input[: -size // 2 - 1 : -1])
             )
         )
         .rolling(size, center=True, min_periods=1)
         .median()
         .to_numpy(input.dtype if dtype is None else dtype)[
-            size // 2: -size // 2
+            size // 2 : -size // 2
         ]
     )
     if np.isnan(filtered_trace).any():
-        filtered_trace = _fill_nan(filtered_trace)
+        filtered_trace = fill_nan(filtered_trace)
     return filtered_trace
 
 
-def _fill_nan(input: np.ndarray) -> np.ndarray:
+def fill_nan(input: np.ndarray) -> np.ndarray:
     """Fill nan values in an array with interpolation
 
     Parameters
@@ -198,11 +208,11 @@ def _nanwelch_1d_array(
             (
                 data_1d[: max_num_samples // 3],
                 data_1d[
-                    int(T // 2 - max_num_samples / 6): int(
+                    int(T // 2 - max_num_samples / 6) : int(
                         T // 2 + max_num_samples / 6
                     )
                 ],
-                data_1d[-max_num_samples // 3:],
+                data_1d[-max_num_samples // 3 :],
             ),
         )
     if T < nperseg:  # return NaN if not enough non-NaN values
@@ -414,11 +424,11 @@ def noise_std(
                     x[..., : max_num_samples // 3],
                     x[
                         ...,
-                        int(T // 2 - max_num_samples / 6): int(
+                        int(T // 2 - max_num_samples / 6) : int(
                             T // 2 + max_num_samples / 6
                         ),
                     ],
-                    x[..., -max_num_samples // 3:],
+                    x[..., -max_num_samples // 3 :],
                 ),
                 axis=-1,
             )

--- a/src/aind_ophys_utils/summary_images.py
+++ b/src/aind_ophys_utils/summary_images.py
@@ -1,6 +1,6 @@
 """ Summary images for calcium imaging movie data """
 from multiprocessing.pool import ThreadPool
-from typing import Union
+
 
 import h5py
 import numpy as np
@@ -10,10 +10,42 @@ from aind_ophys_utils.array_utils import _downsample_array, downsample_array
 from aind_ophys_utils.signal_utils import noise_std
 
 
+def nanstd(input, dim=None, correction=1, keepdim=False):
+    """Calculates the standard deviation, ignoring NaNs,
+    over the dimensions specified by dim.
+
+    Parameters
+    ----------
+    input: torch.Tensor
+        The input tensor.
+    dim: int or tuple of ints:
+        The dimension or dimensions to reduce.
+        Default is None, which reduces all dimensions.
+    correction: int
+        Difference between the sample size and sample degrees of freedom.
+        Defaults to Bessel’s correction, correction=1.
+    keepdim: bool
+        Whether the output tensor has dim retained or not.
+
+    Returns
+    -------
+    std: torch.Tensor
+        The standard deviation of the input tensor, ignoring NaNs.
+    """
+    mask = ~torch.isnan(input)
+    mean = torch.nanmean(input, dim=dim, keepdim=True)
+    squared_deviations = torch.square(input - mean) * mask
+    variance = torch.nansum(squared_deviations, dim=dim, keepdim=keepdim) / (
+        mask.sum(dim=dim, keepdim=keepdim) - correction
+    )
+    return torch.sqrt(variance)
+
+
 def local_correlations(
     mov: np.ndarray,
     eight_neighbours: bool = True,
     device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    skipna: bool = False,
 ) -> np.ndarray:
     """Computes the correlation image for the input dataset mov
 
@@ -25,6 +57,8 @@ def local_correlations(
         Use 8 neighbors if true, and 4 if false.
     device: str
         'cuda' or 'cpu', default is 'cuda' if GPU is available.
+    skipna: bool
+        Exclude NaN values when computing the result.
 
     Returns
     -------
@@ -33,16 +67,14 @@ def local_correlations(
     """
     Y = torch.tensor(mov, dtype=torch.float32, device=device)
     rho = torch.zeros(Y.shape[1:], device=device)
-    w_mov = (Y - torch.mean(Y, axis=0)) / (
-        torch.std(Y, axis=0, correction=0) + torch.finfo(torch.float32).eps
+    mean = torch.nanmean if skipna else torch.mean
+    std = nanstd if skipna else torch.std
+    w_mov = (Y - mean(Y, dim=0)) / (
+        std(Y, dim=0, correction=0) + torch.finfo(torch.float32).eps
     )
 
-    rho_h = torch.mean(
-        torch.multiply(w_mov[:, :-1, :], w_mov[:, 1:, :]), axis=0
-    )
-    rho_w = torch.mean(
-        torch.multiply(w_mov[:, :, :-1], w_mov[:, :, 1:]), axis=0
-    )
+    rho_h = mean(torch.multiply(w_mov[:, :-1, :], w_mov[:, 1:, :]), dim=0)
+    rho_w = mean(torch.multiply(w_mov[:, :, :-1], w_mov[:, :, 1:]), dim=0)
 
     rho[:-1, :] += rho_h
     rho[1:, :] += rho_h
@@ -50,10 +82,10 @@ def local_correlations(
     rho[:, 1:] += rho_w
 
     if eight_neighbours:
-        rho_d1 = torch.mean(
+        rho_d1 = mean(
             torch.multiply(w_mov[:, 1:, :-1], w_mov[:, :-1, 1:]), axis=0
         )
-        rho_d2 = torch.mean(
+        rho_d2 = mean(
             torch.multiply(w_mov[:, :-1, :-1], w_mov[:, 1:, 1:,]), axis=0
         )
 
@@ -84,11 +116,12 @@ def local_correlations(
 
 
 def max_corr_image(
-    mov: Union[h5py.Dataset, np.ndarray],
+    mov: h5py.Dataset | np.ndarray,
     downscale: int = 10,
     bin_size: int = 50,
     eight_neighbours: bool = True,
     device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    skipna: bool = False,
     low_memory: bool = False,
 ) -> np.ndarray:
     """Computes the max-correlation image for the input movie.
@@ -97,7 +130,7 @@ def max_corr_image(
 
     Parameters
     ----------
-    mov: Union[h5py.Dataset, np.ndarray]
+    mov: h5py.Dataset | np.ndarray
         Input movie data.
     downscale: int
         Temporal downscale factor.
@@ -107,6 +140,8 @@ def max_corr_image(
         Use 8 neighbors if true, and 4 if false.
     device: str
         'cuda' or 'cpu', default is 'cuda' if GPU is available.
+    skipna: bool
+        Exclude NaN values when computing the result.
     low_memory: bool
         Setting low_memory to True enforces chunked processing also
         for compressed datasets to save memory.
@@ -121,41 +156,59 @@ def max_corr_image(
     """
     T = mov.shape[0]
     if downscale > 1:
-        T = (T-1) // downscale + 1
+        T = (T - 1) // downscale + 1
     n_bins = max(1, int(np.round(T / bin_size)))
     bins = np.round(np.linspace(0, T, n_bins + 1)).astype(int)
     # downscale first (entire downscaled movie resides in RAM) then chunk
-    if (downscale == 1
-        or n_bins <= 5
-        or (isinstance(mov, h5py.Dataset)
-            and mov.compression
-            and not low_memory)):
+    if (
+        downscale == 1 or
+        n_bins <= 5 or
+        (isinstance(mov, h5py.Dataset) and mov.compression and not low_memory)
+    ):
         if downscale > 1:
-            mov = downsample_array(mov, factors=downscale)
-        return np.max([
-            local_correlations(
-                mov[bins[i]:bins[i + 1]], eight_neighbours, device
-            )
-            for i in range(n_bins)], 0)
+            mov = downsample_array(mov, factors=downscale, skipna=skipna)
+        return np.max(
+            [
+                local_correlations(
+                    mov[bins[i]: bins[i + 1]
+                        ], eight_neighbours, device, skipna=skipna
+                )
+                for i in range(n_bins)
+            ],
+            0,
+        )
     # chunk first then downscale
-    return np.max(ThreadPool().map(lambda i: local_correlations(
-        downsample_array(mov[bins[i]*downscale:bins[i + 1]
-                         * downscale], factors=downscale, n_jobs=1),
-        eight_neighbours, device
-    ), range(n_bins)), 0)
+    return (np.nanmax if skipna else np.max)(
+        ThreadPool().map(
+            lambda i: local_correlations(
+                downsample_array(
+                    mov[bins[i] * downscale: bins[i + 1] * downscale],
+                    factors=downscale,
+                    n_jobs=1,
+                    skipna=skipna,
+                ),
+                eight_neighbours,
+                device,
+                skipna=skipna,
+            ),
+            range(n_bins),
+        ),
+        0,
+    )
 
 
 def pnr_image(
-    mov: Union[h5py.Dataset, np.ndarray],
+    mov: h5py.Dataset | np.ndarray,
     downscale: int = 10,
     method: str = "welch",
     device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    skipna: bool = False,
 ) -> np.ndarray:
     """Computes the peak-to-noise ratio (PNR) image for the input dataset mov
 
     Parameters
     ----------
-    mov: Union[h5py.Dataset, np.ndarray]
+    mov: h5py.Dataset | np.ndarray
         Input movie data.
     downscale: int
         Temporal downscale factor.
@@ -171,6 +224,8 @@ def pnr_image(
                      using Welch's slower but more accurate method.
     device: str
         'cuda' or 'cpu', default is 'cuda' if GPU is available.
+    skipna: bool
+        Exclude NaN values when computing the result.
 
     Returns
     -------
@@ -178,13 +233,15 @@ def pnr_image(
         peak-to-noise ratio (PNR) image
     """
     if downscale > 1:
-        mov = downsample_array(mov, factors=downscale)
-    noise = noise_std(mov, method, axis=0, device=device)
+        mov = downsample_array(mov, factors=downscale, skipna=skipna)
+    noise = noise_std(mov, method, axis=0, device=device, skipna=skipna)
+    if skipna:
+        return (np.nanmax(mov, 0) - np.nanmedian(mov, 0)) / noise
     return (np.max(mov, 0) - np.median(mov, 0)) / noise
 
 
 def max_image(
-    mov: Union[h5py.Dataset, np.ndarray],
+    mov: h5py.Dataset | np.ndarray,
     downscale: int = 1,
     batch_size: int = 500,
     skipna: bool = False,
@@ -195,7 +252,7 @@ def max_image(
 
     Parameters
     ----------
-    mov: Union[h5py.Dataset, np.ndarray]
+    mov: h5py.Dataset | np.ndarray
         Input movie data.
     downscale: int
         Temporal downscale factor.
@@ -218,7 +275,7 @@ def max_image(
 
 
 def mean_image(
-    mov: Union[h5py.Dataset, np.ndarray],
+    mov: h5py.Dataset | np.ndarray,
     batch_size: int = 500,
     skipna: bool = False,
 ) -> np.ndarray:
@@ -227,7 +284,7 @@ def mean_image(
 
     Parameters
     ----------
-    mov: Union[h5py.Dataset, np.ndarray]
+    mov: h5py.Dataset | np.ndarray
         Input movie data.
     batch_size: int
         Number of frames in each batch.
@@ -255,7 +312,7 @@ def mean_image(
 
 
 def var_image(
-    mov: Union[h5py.Dataset, np.ndarray],
+    mov: h5py.Dataset | np.ndarray,
     downscale: int = 1,
     batch_size: int = 500,
     skipna: bool = False,
@@ -266,7 +323,7 @@ def var_image(
 
     Parameters
     ----------
-    mov: Union[h5py.Dataset, np.ndarray]
+    mov: h5py.Dataset | np.ndarray
         Input movie data.
     downscale: int
         Temporal downscale factor.

--- a/src/aind_ophys_utils/video_utils.py
+++ b/src/aind_ophys_utils/video_utils.py
@@ -1,6 +1,6 @@
 """ Utils for video generation """
 from pathlib import Path
-from typing import Union
+
 
 import h5py
 import imageio_ffmpeg as mpg
@@ -44,7 +44,7 @@ def downsample_h5_video(
 
 
 def encode_video(
-    video: Union[h5py.Dataset, np.ndarray],
+    video: h5py.Dataset | np.ndarray,
     output_path: str,
     fps: float,
     bitrate: str = "0",

--- a/tests/test_baseline_fitting.py
+++ b/tests/test_baseline_fitting.py
@@ -1,0 +1,567 @@
+"""Tests for baseline_fitting.py.
+
+Run with:  pytest tests/test_baseline_fitting.py -v
+"""
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend — must be set before pyplot import.
+
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from aind_ophys_utils.baseline_fitting import (  # noqa: E402
+    AsymmetricTukeyBiweight,
+    OneSidedTukeyBiweight,
+    TukeyBiweight,
+    fit_baseline,
+    fit_baseline_fluctuations,
+    nonlinear_fit,
+    robust_lowess,
+    sum_of_exps,
+)
+
+
+RNG = np.random.default_rng(42)
+
+
+# ---------------------------------------------------------------------------
+# 1. sum_of_exps — single_exp, double_exp, and bright cases
+# ---------------------------------------------------------------------------
+
+class TestSumOfExps:
+    """Exercise sum_of_exps for all three classic cases."""
+
+    def test_single_exp_value(self):
+        """3 params (odd) → b_inf + b*exp(-t/tau)."""
+        t = np.linspace(0, 100, 200)
+        params = np.array([10.0, 5.0, 50.0])  # b_inf, b, tau
+        y = sum_of_exps(params, t)
+        expected = 10.0 + 5.0 * np.exp(-t / 50.0)
+        assert np.allclose(y, expected)
+
+    def test_single_exp_jacobian(self):
+        """return_jac=True returns (y, J) of shape (200, 3)."""
+        t = np.linspace(0, 100, 200)
+        params = np.array([10.0, 5.0, 50.0])
+        y, J = sum_of_exps(params, t, return_jac=True)
+        assert y.shape == (200,)
+        assert J.shape == (200, 3)
+        assert np.allclose(J[:, 0], 1.0)
+        assert np.allclose(J[:, 1], np.exp(-t / 50.0))
+
+    def test_double_exp_value(self):
+        """5 params (odd) → b_inf + b1*exp(-t/tau1) + b2*exp(-t/tau2)."""
+        t = np.linspace(0, 100, 200)
+        # [b_inf, b1, tau1, b2, tau2]
+        params = np.array([10.0, 5.0, 50.0, 3.0, 5.0])
+        y = sum_of_exps(params, t)
+        expected = 10.0 + 5.0 * np.exp(-t / 50.0) + 3.0 * np.exp(-t / 5.0)
+        assert np.allclose(y, expected)
+
+    def test_double_exp_jacobian(self):
+        """return_jac=True returns (y, J) of shape (200, 5)."""
+        t = np.linspace(0, 100, 200)
+        params = np.array([10.0, 5.0, 50.0, 3.0, 5.0])
+        y, J = sum_of_exps(params, t, return_jac=True)
+        assert J.shape == (200, 5)
+
+    def test_quad_exp_value(self):
+        """9 params (odd) → b_inf + 4 exponentials; negative amplitude gives subtraction."""
+        t = np.linspace(0, 100, 100)
+        # [b_inf, b_slow, tau_slow, b_fast, tau_fast,
+        #  b_rapid, tau_rapid, b_bright, tau_bright]
+        # b_bright is negative to represent suppression
+        params = np.array([100.0, 10.0, 1800.0, 5.0, 60.0, 2.0, 10.0, -20.0, 50.0])
+        y = sum_of_exps(params, t)
+        b_inf, b1, tau1, b2, tau2, b3, tau3, b4, tau4 = params
+        expected = (
+            b_inf
+            + b1 * np.exp(-t / tau1)
+            + b2 * np.exp(-t / tau2)
+            + b3 * np.exp(-t / tau3)
+            + b4 * np.exp(-t / tau4)
+        )
+        assert np.allclose(y, expected)
+
+    def test_quad_exp_jacobian(self):
+        """return_jac=True returns a (100, 9) Jacobian for 9-param model."""
+        t = np.linspace(0, 100, 100)
+        params = np.array([100.0, 10.0, 1800.0, 5.0, 60.0, 2.0, 10.0, -20.0, 50.0])
+        y, J = sum_of_exps(params, t, return_jac=True)
+        assert J.shape == (100, 9)
+
+    def test_even_params_no_constant(self):
+        """2 params (even) → no b_inf, just b*exp(-t/tau)."""
+        t = np.linspace(0, 100, 50)
+        params = np.array([5.0, 30.0])  # b, tau
+        y = sum_of_exps(params, t)
+        expected = 5.0 * np.exp(-t / 30.0)
+        assert np.allclose(y, expected)
+
+    def test_jax_backend(self):
+        """sum_of_exps traces correctly with xp=jnp."""
+        import jax.numpy as jnp
+        t = np.linspace(0, 100, 50)
+        params = np.array([10.0, 5.0, 50.0])
+        y = sum_of_exps(params, jnp.asarray(t), xp=jnp)
+        expected = 10.0 + 5.0 * np.exp(-t / 50.0)
+        assert np.allclose(np.array(y), expected)
+
+
+# ---------------------------------------------------------------------------
+# 2. Tukey-biweight norms — exercise the rho/psi/weights branches
+# ---------------------------------------------------------------------------
+
+class TestNorms:
+    """Cover ATB validation + psi/weights/psi_deriv + OneSided / Tukey subclasses."""
+
+    def test_init_rejects_nonpositive_c(self):
+        """Constructor raises on c_pos<=0."""
+        with pytest.raises(ValueError, match="positive"):
+            AsymmetricTukeyBiweight(c_pos=0.0)
+        with pytest.raises(ValueError, match="positive"):
+            AsymmetricTukeyBiweight(c_neg=-1.0)
+
+    def test_psi_and_weights_and_psi_deriv(self):
+        """psi, weights and psi_deriv produce expected values inside/outside cutoff."""
+        M = AsymmetricTukeyBiweight(c_pos=4.0, c_neg=4.0)
+        # Inside the cutoff
+        assert M.psi(1.0) != 0.0
+        assert M.weights(1.0) > 0.0
+        assert M.psi_deriv(0.0) == pytest.approx(1.0)
+        # Outside the cutoff
+        assert M.psi(10.0) == 0.0
+        assert M.weights(10.0) == 0.0
+        assert M.psi_deriv(10.0) == 0.0
+
+    def test_one_sided_quadratic_on_negative_side(self):
+        """OneSidedTukeyBiweight has c_neg=inf → _rho_half uses 0.5*z**2."""
+        M = OneSidedTukeyBiweight(c=4.685)
+        # Large negative residual → uses the quadratic branch.
+        assert M.rho(-3.0) == pytest.approx(0.5 * 9.0)
+
+    def test_tukey_biweight_symmetric_rho(self):
+        """TukeyBiweight.rho is symmetric and matches _rho_half."""
+        M = TukeyBiweight(c=4.685)
+        assert M.rho(1.0) == pytest.approx(M.rho(-1.0))
+
+
+# ---------------------------------------------------------------------------
+# 3. nonlinear_fit — numpy backend (OLS + robust IRLS)
+# ---------------------------------------------------------------------------
+
+def _decay_trace(noise_sd=0.5, T=400):
+    """Synthesise a single-exp decay trace at uniform 1 Hz sampling."""
+    t = np.arange(T, dtype=float)
+    true_params = np.array([5.0, 10.0, 30.0])  # b_inf, b, tau
+    y = sum_of_exps(true_params, t) + RNG.normal(0, noise_sd, size=T)
+    return y, t, true_params
+
+
+class TestNonlinearFitNumpy:
+    """nonlinear_fit on the numpy backend."""
+
+    def test_ols_with_jacobian(self):
+        """numpy backend, OLS path, model supplies a Jacobian."""
+        y, t, true = _decay_trace()
+        x0 = np.array([1.0, 1.0, 50.0])
+        fitted, res = nonlinear_fit(y, t, sum_of_exps, x0, backend="numpy")
+        assert fitted.shape == y.shape
+        assert np.allclose(res.x, true, atol=2.0)
+
+    def test_ols_with_weights(self):
+        """numpy OLS branch with per-point weights."""
+        y, t, _ = _decay_trace()
+        w = np.ones_like(y)
+        x0 = np.array([1.0, 1.0, 50.0])
+        _, res = nonlinear_fit(
+            y, t, sum_of_exps, x0, backend="numpy", weights=w,
+        )
+        assert res.success or res.status >= 0
+
+    def test_robust_irls(self):
+        """numpy IRLS branch with an M-estimator."""
+        y, t, true = _decay_trace(noise_sd=0.3)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight(c_pos=4.685, c_neg=4.685)
+        fitted, res = nonlinear_fit(
+            y, t, sum_of_exps, x0, backend="numpy", M=M, fixed_sigma=0.3,
+        )
+        assert fitted.shape == y.shape
+        assert np.allclose(res.x, true, atol=2.0)
+
+
+# ---------------------------------------------------------------------------
+# 4. nonlinear_fit — JAX backend smoke test so the public API stays covered.
+# ---------------------------------------------------------------------------
+
+class TestNonlinearFitJax:
+    """nonlinear_fit on the JAX backend, with an M-estimator."""
+
+    def test_jax_robust(self):
+        """JAX backend with M-estimator and fixed_sigma → exercises robust_val_grad."""
+        y, t, true = _decay_trace(noise_sd=0.3)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight(c_pos=4.685, c_neg=4.685)
+        fitted, res = nonlinear_fit(
+            y, t, sum_of_exps, x0,
+            backend="jax", M=M, fixed_sigma=0.3, dtype=jnp.float64,
+        )
+        assert fitted.shape == y.shape
+        assert np.allclose(res.x, true, atol=2.0)
+
+
+# ---------------------------------------------------------------------------
+# 5. fit_baseline — round-2 sigma relaxation path
+# ---------------------------------------------------------------------------
+
+class TestFitBaselineRound2:
+    """Trigger the round-2 sigma relaxation logic in fit_baseline."""
+
+    def test_round_2_triggered_by_high_threshold(self):
+        """sigma_relax_threshold=0.99 → almost always triggers round 2."""
+        y, t, _ = _decay_trace(noise_sd=0.3)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight(c_pos=2.0, c_neg=3.0)
+        _, F0trend, res, _ = fit_baseline(
+            y, t, sum_of_exps, x0,
+            backend="jax", M=M, fixed_sigma=0.3,
+            sigma_relax_threshold=0.99,  # forces round 2
+        )
+        assert F0trend.shape == y.shape
+        assert res.round in (1, 2)
+
+    def test_round_1_when_frac_below_sufficient(self):
+        """sigma_relax_threshold=0.0 → round 1 always sufficient."""
+        y, t, _ = _decay_trace(noise_sd=0.3)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight(c_pos=4.685, c_neg=4.685)
+        _, F0trend, res, _ = fit_baseline(
+            y, t, sum_of_exps, x0,
+            backend="numpy", M=M, fixed_sigma=0.3,
+            sigma_relax_threshold=0.0,  # never triggers round 2
+        )
+        assert res.round == 1
+
+
+# ---------------------------------------------------------------------------
+# 5b. nonlinear_fit — sigma annealing under heavy one-sided activity
+# ---------------------------------------------------------------------------
+
+# Statistics measured from a real 56-ROI fluorescence recording (traces.npy):
+# noise CV ~9% (median), activity fraction up to ~0.58, and trends that both
+# decay and rise (median bleach negative). The fixtures below are calibrated to
+# those numbers so the ground-truth tests stay representative of real data.
+_DECAY_PARAMS = (5.0, 10.0, 30.0)     # b_inf, b, tau  → falls 15 → 5
+_RISING_PARAMS = (15.0, -10.0, 30.0)  # negative amplitude → anti-bleach, rises 5 → 15
+
+
+def _high_activity_trace(activity_frac, amp, noise_cv=0.09, T=400, seed=7,
+                         true_params=_DECAY_PARAMS):
+    """Baseline + one-sided (positive) activity transients + realistic noise.
+
+    The noise scale is set from ``noise_cv`` times the mean baseline level
+    (~9% matches real traces); ``amp`` is the transient height in units of that
+    noise scale. Pass ``_RISING_PARAMS`` for an anti-bleach (rising) trend.
+    Returns ``(y, t, base, noise_sd)`` — ``noise_sd`` is the ground-truth scale
+    to pass as ``fixed_sigma``.
+    """
+    rng = np.random.default_rng(seed)
+    t = np.arange(T, dtype=float)
+    base = sum_of_exps(np.array(true_params), t)
+    noise_sd = noise_cv * float(np.mean(np.abs(base)))
+    y = base + rng.normal(0, noise_sd, T)
+    idx = rng.choice(T, int(activity_frac * T), replace=False)
+    y[idx] += amp * noise_sd * rng.exponential(1.0, len(idx))
+    return y, t, base, noise_sd
+
+
+class TestNonlinearFitSigmaAnneal:
+    """Graduated sigma annealing recovers the baseline under heavy activity.
+
+    Coverage of the annealing code is already provided by the round-2/MAD-sigma
+    tests; these assert the *behaviour* — that annealing recovers the baseline
+    where the legacy single jump (steps=1) does not, and that turning it on by
+    default leaves the low-activity regime unchanged.
+    """
+
+    BOUNDS = [(-50, 50), (-50, 50), (1, 200)]
+    X0 = np.array([1.0, 1.0, 50.0])
+    M = AsymmetricTukeyBiweight(c_pos=2.0, c_neg=3.0)
+
+    def _fit(self, y, t, steps, sigma):
+        """Trend fit at the given anneal-step count; returns the fitted curve."""
+        fitted, _ = nonlinear_fit(
+            y, t, sum_of_exps, self.X0, self.BOUNDS,
+            M=self.M, fixed_sigma=sigma, sigma_anneal_steps=steps,
+        )
+        return fitted
+
+    # decay (falls 15→5) at 60% activity — just above the busiest real ROIs
+    # (~58%) — collapses the single jump; rising (anti-bleach, 5→15) at the real
+    # p90 activity (~50%) is mild enough that both succeed, so there annealing
+    # only has to match, not beat, the jump.
+    @pytest.mark.parametrize("params, act, jump_collapses", [
+        (_DECAY_PARAMS, 0.60, True),
+        (_RISING_PARAMS, 0.50, False),
+    ])
+    def test_annealing_recovers_baseline(self, params, act, jump_collapses):
+        """Annealing recovers the truth and is never worse than the single jump."""
+        y, t, base, sd = _high_activity_trace(act, amp=8.0, true_params=params)
+        rmse = lambda f: float(np.sqrt(np.mean((f - base) ** 2)))  # noqa: E731
+        r_anneal = rmse(self._fit(y, t, 4, sd))
+        r_jump = rmse(self._fit(y, t, 1, sd))
+        assert r_anneal < sd                          # annealing recovers the truth
+        # never worse than the jump, tolerant of optimizer/BLAS jitter (~1e-9)
+        assert r_anneal <= r_jump + 1e-6 * sd + 1e-9
+        if jump_collapses:
+            assert r_jump > sd                        # single jump lands in bad basin
+
+    def test_easy_regime_unaffected_by_anneal_steps(self):
+        """Sparse activity: annealing and single-jump converge to the same fit."""
+        y, t, _, sd = _high_activity_trace(0.10, amp=6.0)
+        assert np.allclose(self._fit(y, t, 1, sd), self._fit(y, t, 4, sd),
+                           atol=1e-4 * sd + 1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 6. robust_lowess — both with and without M
+# ---------------------------------------------------------------------------
+
+class TestRobustLowess:
+    """Cover robust_lowess M=None and M=ATB paths."""
+
+    def test_no_irls(self):
+        """M=None → single-pass LOWESS, sigma is None."""
+        T = 400
+        t = np.arange(T, dtype=float)
+        y = np.sin(t / 30.0) + RNG.normal(0, 0.1, size=T)
+        fluctuation, w, sigma = robust_lowess(y, t, frac=0.1, M=None)
+        assert fluctuation.shape == (T,)
+        assert sigma is None
+        assert np.all(w == 1.0)
+
+    def test_with_irls(self):
+        """M given → runs the outer IRLS loop, returns finite sigma."""
+        T = 400
+        t = np.arange(T, dtype=float)
+        y = np.sin(t / 30.0) + RNG.normal(0, 0.1, size=T)
+        M = AsymmetricTukeyBiweight()
+        fluctuation, w, sigma = robust_lowess(
+            y, t, frac=0.1, M=M, maxiter=3,
+        )
+        assert fluctuation.shape == (T,)
+        assert sigma is not None and sigma > 0
+
+    def test_fixed_sigma(self):
+        """fixed_sigma bypasses the per-iteration MAD estimate."""
+        T = 400
+        t = np.arange(T, dtype=float)
+        y = np.sin(t / 30.0) + RNG.normal(0, 0.1, size=T)
+        M = AsymmetricTukeyBiweight()
+        _, _, sigma = robust_lowess(
+            y, t, frac=0.1, M=M, maxiter=2, fixed_sigma=0.2,
+        )
+        assert sigma == 0.2
+
+
+# ---------------------------------------------------------------------------
+# 7. fit_baseline_fluctuations — ratio + subtract + percentile branches
+# ---------------------------------------------------------------------------
+
+class TestFitBaselineFluctuations:
+    """Cover the dispatch matrix of fit_baseline_fluctuations."""
+
+    def _trace_and_trend(self, T=400):
+        """Synthesise a (trace, t, trend) tuple with a slow exponential trend."""
+        t = np.arange(T, dtype=float)
+        trend = 50.0 + 20.0 * np.exp(-t / 100.0)
+        signal = trend * (1.0 + 0.05 * np.sin(t / 20.0)) + RNG.normal(0, 0.5, size=T)
+        return signal, t, trend
+
+    def test_lowess_ratio_with_trend(self):
+        """method=lowess + mode=ratio → fluctuation is dimensionless and >0."""
+        trace, t, trend = self._trace_and_trend()
+        baseline, fluctuation, info = fit_baseline_fluctuations(
+            trace, t, trend=trend, mode="ratio", method="lowess",
+        )
+        assert baseline.shape == trace.shape
+        assert "lowess_weights" in info
+
+    def test_lowess_subtract_with_trend(self):
+        """method=lowess + mode=subtract → fluctuation is additive."""
+        trace, t, trend = self._trace_and_trend()
+        baseline, fluctuation, info = fit_baseline_fluctuations(
+            trace, t, trend=trend, mode="subtract", method="lowess",
+        )
+        assert baseline.shape == trace.shape
+
+    def test_lowess_no_trend(self):
+        """trend=None branch → baseline == fluctuation."""
+        trace, t, _ = self._trace_and_trend()
+        baseline, fluctuation, _ = fit_baseline_fluctuations(
+            trace, t, trend=None, method="lowess",
+        )
+        assert np.allclose(baseline, fluctuation)
+
+    def test_percentile_branch(self):
+        """method=percentile path is exercised."""
+        trace, t, trend = self._trace_and_trend()
+        baseline, _, info = fit_baseline_fluctuations(
+            trace, t, trend=trend, mode="subtract", method="percentile", window=40.0,
+        )
+        assert "percentile" in info and "size" in info
+
+    def test_unknown_method_raises(self):
+        """An unrecognised method raises ValueError."""
+        trace, t, trend = self._trace_and_trend()
+        with pytest.raises(ValueError, match="Unknown method"):
+            fit_baseline_fluctuations(
+                trace, t, trend=trend, method="totally_invalid",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 8. fit_baseline — the high-level orchestrator
+# ---------------------------------------------------------------------------
+
+class TestFitBaseline:
+    """Cover the fit_baseline orchestrator and its M_fluctuations defaulting."""
+
+    def test_fit_baseline_no_M(self):
+        """M=None → M_fluctuations=None branch."""
+        y, t, _ = _decay_trace(noise_sd=0.5, T=300)
+        x0 = np.array([1.0, 1.0, 50.0])
+        F0, F0trend, res, info = fit_baseline(
+            y, t, sum_of_exps, x0, backend="numpy",
+        )
+        assert F0.shape == y.shape
+        assert F0trend.shape == y.shape
+        assert "lowess_weights" in info
+
+    def test_fit_baseline_with_M(self):
+        """M=ATB → M_fluctuations derived via with_xp(np)."""
+        y, t, _ = _decay_trace(noise_sd=0.5, T=300)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight()
+        F0, F0trend, res, info = fit_baseline(
+            y, t, sum_of_exps, x0, backend="numpy", M=M, fixed_sigma=0.5,
+        )
+        assert F0.shape == y.shape
+
+
+# ---------------------------------------------------------------------------
+# 9. nonlinear_fit — model-without-return_jac path
+# ---------------------------------------------------------------------------
+
+def _sum_of_exps_no_jac(params, t):
+    """Wrapper around sum_of_exps that exposes no ``return_jac`` parameter.
+
+    Used to force ``has_return_jac=False`` so the value-only branches of the
+    numpy-backend objective factories are exercised.
+    """
+    return sum_of_exps(params, t)
+
+
+class TestNonlinearFitNoJacobianModel:
+    """When the model has no return_jac parameter, the objective uses the value-only path."""
+
+    def test_ols_value_only_path(self):
+        """numpy OLS without a model Jacobian."""
+        y, t, _ = _decay_trace()
+        x0 = np.array([1.0, 1.0, 50.0])
+        fitted, res = nonlinear_fit(y, t, _sum_of_exps_no_jac, x0, backend="numpy")
+        assert fitted.shape == y.shape
+
+    def test_robust_value_only_path(self):
+        """numpy IRLS without a model Jacobian."""
+        y, t, _ = _decay_trace(noise_sd=0.3)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight()
+        fitted, res = nonlinear_fit(
+            y, t, _sum_of_exps_no_jac, x0,
+            backend="numpy", M=M, fixed_sigma=0.3,
+        )
+        assert fitted.shape == y.shape
+
+
+# ---------------------------------------------------------------------------
+# 10. nonlinear_fit IRLS — sigma estimation paths when fixed_sigma is None
+# ---------------------------------------------------------------------------
+
+class TestNonlinearFitMadSigma:
+    """Cover the per-iteration MAD/std sigma estimation branches in _run_irls."""
+
+    def test_numpy_irls_estimates_sigma_each_iter(self):
+        """numpy backend, M given, no fixed_sigma → statsmodels.scale.mad path."""
+        y, t, _ = _decay_trace(noise_sd=0.5, T=300)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight()
+        fitted, res = nonlinear_fit(
+            y, t, sum_of_exps, x0, backend="numpy", M=M, maxiter=2,
+        )
+        assert fitted.shape == y.shape
+
+    def test_jax_irls_estimates_sigma_each_iter(self):
+        """JAX backend, M given, no fixed_sigma → jnp.median MAD path."""
+        y, t, _ = _decay_trace(noise_sd=0.5, T=300)
+        x0 = np.array([1.0, 1.0, 50.0])
+        M = AsymmetricTukeyBiweight()
+        fitted, res = nonlinear_fit(
+            y, t, sum_of_exps, x0,
+            backend="jax", M=M, maxiter=2, dtype=jnp.float64,
+        )
+        assert fitted.shape == y.shape
+
+    def test_numpy_irls_sigma_zero_falls_back_to_std(self):
+        """When MAD == 0 (noiseless trace fits exactly), sigma falls back to std.
+
+        With a noiseless trace the OLS pre-pass converges to ground truth so
+        ``resid`` is all zeros → ``scale.mad`` returns 0 and the fallback
+        ``np.std(resid)`` branch runs (also 0, but the code path is hit).
+        """
+        T = 200
+        t = np.arange(T, dtype=float)
+        true = np.array([5.0, 10.0, 30.0])
+        y = sum_of_exps(true, t)  # NO noise
+        x0 = true.copy()  # start at truth
+        M = AsymmetricTukeyBiweight()
+        # The fit will probably fail or return NaN at sigma=0, but the code path executes.
+        fitted, res = nonlinear_fit(
+            y, t, sum_of_exps, x0, backend="numpy", M=M, maxiter=1,
+        )
+        assert fitted.shape == y.shape
+
+
+# ---------------------------------------------------------------------------
+# 11. robust_lowess — convergence break and sigma=0 fallback
+# ---------------------------------------------------------------------------
+
+class TestRobustLowessEdgeCases:
+    """Cover the remaining robust_lowess branches."""
+
+    def test_loose_tol_triggers_early_convergence(self):
+        """A loose tol triggers the ``if np.max(...) < tol: break`` early-exit."""
+        T = 300
+        t = np.arange(T, dtype=float)
+        y = np.sin(t / 30.0) + RNG.normal(0, 0.1, size=T)
+        M = AsymmetricTukeyBiweight()
+        # tol=1.0 → first iteration's |w_new - w_current| < 1 → immediate break.
+        _, _, sigma = robust_lowess(y, t, frac=0.1, M=M, maxiter=5, tol=1.0)
+        assert sigma is not None
+
+    def test_zero_mad_falls_back_to_std(self):
+        """When LOWESS residuals are ~0, MAD=0 → fall back to std.
+
+        A perfectly-flat signal lets LOWESS recover the exact baseline,
+        producing zero residuals; the sigma estimator then falls through to
+        np.std (which is also 0 here, but the branch is exercised).
+        """
+        T = 300
+        t = np.arange(T, dtype=float)
+        y = np.full(T, 5.0)  # exactly constant → LOWESS fits perfectly → residuals are 0
+        M = AsymmetricTukeyBiweight()
+        _, _, sigma = robust_lowess(y, t, frac=0.1, M=M, maxiter=1)
+        # sigma may be 0 or a tiny float (numerical noise) — the branch was taken.
+        assert sigma is not None and abs(sigma) < 1e-10

--- a/tests/test_dff.py
+++ b/tests/test_dff.py
@@ -1,11 +1,50 @@
 """Tests dff"""
 from itertools import product
 
+import matplotlib
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
 
-from aind_ophys_utils.dff import dff
+from aind_ophys_utils.dff import dff, plot_dff
+
+matplotlib.use("Agg")
+
+
+RNG = np.random.default_rng(42)
+
+
+# ---------------------------------------------------------------------------
+# plot_dff — smoke tests covering trend-only and full-baseline paths
+# ---------------------------------------------------------------------------
+
+class TestPlotDff:
+    """Smoke-test plot_dff to cover both rendering paths."""
+
+    def _data(self, T=400):
+        """Synthesise (F, F0, F0trend, t) inputs suitable for plot_dff."""
+        t = np.linspace(0.0, 100.0, T)
+        F0trend = 50.0 + 20.0 * np.exp(-t / 30.0)
+        F0 = F0trend * (1.0 + 0.02 * np.sin(t / 5.0))
+        F = F0 * (1.0 + RNG.normal(0, 0.02, size=T))
+        return F, F0, F0trend, t
+
+    # every mode (full baseline / trend-only) × inset (on / off) combination
+    @pytest.mark.parametrize("with_trend, zoom", [
+        (True, 20.0),    # full baseline + insets  → 6-row layout
+        (True, None),    # full baseline, no insets → 4-row layout
+        (False, 20.0),   # trend-only + insets      → 3-row layout
+        (False, None),   # trend-only, no insets    → 2-row layout
+    ])
+    def test_render_paths(self, with_trend, zoom):
+        """plot_dff returns a figure for every mode × inset combination."""
+        import matplotlib.pyplot as plt
+
+        F, F0, F0trend, t = self._data()
+        fig = plot_dff(F, F0, t, F0trend if with_trend else None,
+                       zoom_duration=zoom, roi_id=42 if with_trend else None)
+        assert fig is not None
+        plt.close("all")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dff.py
+++ b/tests/test_dff.py
@@ -1,4 +1,5 @@
 """Tests dff"""
+
 from itertools import product
 
 import matplotlib
@@ -18,6 +19,7 @@ RNG = np.random.default_rng(42)
 # plot_dff — smoke tests covering trend-only and full-baseline paths
 # ---------------------------------------------------------------------------
 
+
 class TestPlotDff:
     """Smoke-test plot_dff to cover both rendering paths."""
 
@@ -30,19 +32,28 @@ class TestPlotDff:
         return F, F0, F0trend, t
 
     # every mode (full baseline / trend-only) × inset (on / off) combination
-    @pytest.mark.parametrize("with_trend, zoom", [
-        (True, 20.0),    # full baseline + insets  → 6-row layout
-        (True, None),    # full baseline, no insets → 4-row layout
-        (False, 20.0),   # trend-only + insets      → 3-row layout
-        (False, None),   # trend-only, no insets    → 2-row layout
-    ])
+    @pytest.mark.parametrize(
+        "with_trend, zoom",
+        [
+            (True, 20.0),  # full baseline + insets  → 6-row layout
+            (True, None),  # full baseline, no insets → 4-row layout
+            (False, 20.0),  # trend-only + insets      → 3-row layout
+            (False, None),  # trend-only, no insets    → 2-row layout
+        ],
+    )
     def test_render_paths(self, with_trend, zoom):
         """plot_dff returns a figure for every mode × inset combination."""
         import matplotlib.pyplot as plt
 
         F, F0, F0trend, t = self._data()
-        fig = plot_dff(F, F0, t, F0trend if with_trend else None,
-                       zoom_duration=zoom, roi_id=42 if with_trend else None)
+        fig = plot_dff(
+            F,
+            F0,
+            t,
+            F0trend if with_trend else None,
+            zoom_duration=zoom,
+            roi_id=42 if with_trend else None,
+        )
         assert fig is not None
         plt.close("all")
 
@@ -59,8 +70,8 @@ class TestPlotDff:
             [5, 7],
             ["welch", "mad"],
         )
-    ) + [(1, 10, 0.1, np.nan, np.nan, 5, "welch"),
-         (1, 10, 0.1, 1, 1, 5, 0.2)],
+    )
+    + [(1, 10, 0.1, np.nan, np.nan, 5, "welch"), (1, 10, 0.1, 1, 1, 5, 0.2)],
 )
 def test_dff(N, fs, rate, tau, b, snr, method):
     """Test dff"""
@@ -77,3 +88,14 @@ def test_dff(N, fs, rate, tau, b, snr, method):
     assert_array_almost_equal(b / snr * np.ones(N), ns, 1)
     assert_array_almost_equal(b * np.ones((N, T)).squeeze(), F0, 1)
     assert_array_almost_equal(C, dF, 0)
+
+
+def test_dff_wide_nan_block():
+    """dff handles a NaN block wider than the filter window via fill_nan."""
+    T = 500
+    F = np.ones(T) * 100.0
+    F[200:300] = (
+        np.nan
+    )  # 100-sample NaN block, wider than typical short window
+    dF, F0, ns = dff(F, fs=10.0, long_window=5, short_window=1)
+    assert not np.isnan(F0).any()  # baseline must be fully interpolated

--- a/tests/test_signal_utils.py
+++ b/tests/test_signal_utils.py
@@ -3,7 +3,7 @@ from itertools import chain, product
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_allclose, assert_array_almost_equal
 
 from aind_ophys_utils.signal_utils import (
     median_filter,
@@ -139,3 +139,17 @@ def test_noise_std(x, expected, method, n_jobs):
     decimal = 0 if method == "fft" else 1
     assert_array_almost_equal(
         expected, noise_std(x, method, n_jobs=n_jobs), decimal)
+
+
+@pytest.mark.parametrize(
+    "x, expected",
+    [
+        (np.array([0, 1, 2, 3, np.nan]), np.nan),  # Has NaN
+        (np.random.randn(20, 10000), [1] * 20),  # just noise
+        (np.random.randn(10000, 1000), [1] * 10000),  # just noise
+        (np.hstack([np.random.randn(9000), [np.nan] * 1000]), 1),  # both
+    ],
+)
+def test_noise_std_nan(x, expected):
+    """Test noise_std with skipna=True"""
+    assert_allclose(noise_std(x, skipna=True), expected, rtol=1e-1, atol=1e-1)

--- a/tests/test_signal_utils.py
+++ b/tests/test_signal_utils.py
@@ -1,4 +1,5 @@
 """Tests signal_utils"""
+
 from itertools import chain, product
 
 import numpy as np
@@ -6,6 +7,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_almost_equal
 
 from aind_ophys_utils.signal_utils import (
+    fill_nan,
     median_filter,
     nanmedian_filter,
     noise_std,
@@ -86,8 +88,42 @@ def test_median(array, size, expected):
 )
 def test_nanmedian_filter(input, size, expected):
     """Test nanmedian_filter"""
-    output = nanmedian_filter(input, size)
+    with pytest.warns(DeprecationWarning):
+        output = nanmedian_filter(input, size)
     assert_array_almost_equal(expected, output)
+
+
+@pytest.mark.parametrize(
+    "array, size, expected",
+    [
+        # No NaNs: matches median_filter
+        (np.arange(100.0), 5, median_filter(np.arange(100.0), 5)),
+        # NaN block narrower than window: rolling fills the gap
+        (
+            np.array([1.0, 2.0, np.nan, 4.0, 5.0]),
+            3,
+            np.array([1.0, 1.5, 3.0, 4.5, 5.0]),
+        ),
+        # NaN block wider than window: NaNs remain (caller's responsibility to fill)
+        (
+            np.array([1.0, np.nan, np.nan, np.nan, np.nan, 5.0]),
+            3,
+            np.array([1.0, 1.0, np.nan, np.nan, 5.0, 5.0]),
+        ),
+    ],
+)
+def test_median_filter_skipna(array, size, expected):
+    """Test median_filter with skipna=True"""
+    output = median_filter(array, size, skipna=True)
+    np.testing.assert_allclose(output, expected, equal_nan=True)
+
+
+def test_fill_nan():
+    """Test fill_nan interpolates NaN values"""
+    arr = np.array([1.0, np.nan, np.nan, 4.0])
+    output = fill_nan(arr)
+    assert_array_almost_equal(output, [1.0, 2.0, 3.0, 4.0])
+    assert not np.isnan(output).any()
 
 
 @pytest.mark.parametrize(
@@ -101,7 +137,7 @@ def test_nanmedian_filter(input, size, expected):
         (np.array([1]), 0.0, -1),  # Unit
         (np.array([-1, 2, 3]), 1.4826, -1),  # Typical
         (np.random.randn(5, 10000), [1] * 5, -1),  # Typical
-        (np.random.randn(10000, 5), [1] * 5, 0),   # Typical
+        (np.random.randn(10000, 5), [1] * 5, 0),  # Typical
     ],
 )
 def test_robust_std(x, expected, axis):
@@ -126,7 +162,7 @@ def test_robust_std(x, expected, axis):
                             np.linspace(0, 100, 200000).reshape(20, 10000)
                         ),
                         [1] * 20,
-                        None
+                        None,
                     ],
                 ],
                 [["welch"], ["mad"], ["fft"]],
@@ -138,7 +174,8 @@ def test_noise_std(x, expected, method, n_jobs):
     """Test noise_std"""
     decimal = 0 if method == "fft" else 1
     assert_array_almost_equal(
-        expected, noise_std(x, method, n_jobs=n_jobs), decimal)
+        expected, noise_std(x, method, n_jobs=n_jobs), decimal
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_summary_images.py
+++ b/tests/test_summary_images.py
@@ -9,39 +9,34 @@ from aind_ophys_utils import summary_images as si
 
 
 @pytest.mark.parametrize(
-    "array, expected",
+    "array, expected, skipna",
     [
-        (np.arange(90).reshape(10, 3, 3), np.ones((3, 3))),
-        (np.ones((10, 3, 3)), np.zeros((3, 3))),
-        (np.nan * np.zeros((10, 3, 3)), np.nan * np.zeros((3, 3))),
+        (np.arange(90).reshape(10, 3, 3), np.ones((3, 3)), False),
+        (np.ones((10, 3, 3)), np.zeros((3, 3)), False),
+        (np.nan * np.zeros((10, 3, 3)), np.nan * np.zeros((3, 3)), False),
+        (np.concatenate([np.arange(90).reshape(10, 3, 3),
+                         np.nan * np.zeros((10, 3, 3))]),
+         np.nan * np.ones((3, 3)), False),
+        (np.concatenate([np.arange(90).reshape(10, 3, 3),
+                         np.nan * np.zeros((10, 3, 3))]),
+         np.ones((3, 3)), True),
     ],
 )
-def test_local_correlations(array, expected):
+def test_local_correlations(array, expected, skipna):
     """Test local_correlations"""
-    output = si.local_correlations(array)
+    output = si.local_correlations(array, skipna=skipna)
     assert_array_almost_equal(expected, output)
 
 
 @pytest.mark.parametrize(
-    "ds, bs, eight",
-    [
-        (1, 2, True),
-        (1, 3, True),
-        (1, 4, True),
-        (1, 5, True),
-        (1, 7, True),
-        (1, 10, True),
-        (2, 2, True),
-        (2, 5, True),
-        (2, 10, True),
-        (2, 10, False),
-    ],
+    "ds, bs, eight, skipna",
+    list(product([1, 2], [2, 5, 10], [False, True], [False, True])),
 )
-def test_max_corr_image(ds, bs, eight):
+def test_max_corr_image(ds, bs, eight, skipna):
     """Test max_corr_image"""
     output = si.max_corr_image(
         np.arange(270).reshape(30, 3, 3), downscale=ds, bin_size=bs,
-        eight_neighbours=eight
+        eight_neighbours=eight, skipna=skipna
     )
     expected = np.ones((3, 3))
     assert_array_almost_equal(expected, output)
@@ -49,13 +44,17 @@ def test_max_corr_image(ds, bs, eight):
 
 @pytest.mark.filterwarnings("ignore:nperseg*:UserWarning")
 @pytest.mark.parametrize(
-    "ds, method",
-    list(product([1, 10, 100], ["welch", "mad", "fft"])),
+    "ds, method, skipna",
+    list(product([1, 10, 100], ["welch", "mad", "fft"], [False])) +
+    list(product([1, 10], ["welch"], [True])),
 )
-def test_pnr_image(ds, method):
+def test_pnr_image(ds, method, skipna):
     """Test pnr_image"""
     output = si.pnr_image(
-        np.random.randn(10000, 3, 3), downscale=ds, method=method
+        np.random.randn(10000, 3, 3),
+        downscale=ds,
+        method=method,
+        skipna=skipna
     )
     expected = {1: 7.7, 10: 6.5, 100: 5.2}[ds]
     decimal = -1 if method == "fft" else 0
@@ -99,9 +98,7 @@ def test_var_image(ds, bs, skipna):
     """Test var_image"""
     data = np.arange(180.).reshape(20, 3, 3)
     data[0, 0, 0] = np.nan
-    output = si.var_image(
-        data, downscale=ds, batch_size=bs, skipna=skipna
-    )
+    output = si.var_image(data, downscale=ds, batch_size=bs, skipna=skipna)
     expected = {1: 2693.25, 2: 2673, 5: 2531.25}[ds] * np.ones((3, 3))
     expected[0, 0] = {1: 2430, 2: 2160, 5: 1350}[ds] if skipna else np.nan
     assert_array_almost_equal(expected, output)


### PR DESCRIPTION
## Summary

- `percentile_filter` now always uses `scipy.ndimage.percentile_filter` (O(log n) since scipy 1.15.0), dropping the custom pandas-based implementation for the non-NaN case
- Added `skipna: bool = False` to `percentile_filter` and `median_filter`; when `True`, falls back to pandas rolling quantile which ignores NaN values within each window
- `fill_nan` renamed from `_fill_nan` (now public)
- `nanmedian_filter` deprecated with `DeprecationWarning`; callers should use `median_filter(..., skipna=True)` followed by `fill_nan` if needed
- `dff._dff_single_trace` updated to use `median_filter(skipna=True)` + `fill_nan` for wide NaN blocks
- Tests added for `skipna=True`, `fill_nan`, and the deprecation warning

## Test plan

- [ ] `pytest tests/test_signal_utils.py` — all 51 pass
- [ ] `black`, `isort` applied; E203 violations are pre-existing black/flake8 incompatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)