### PR TITLE
style: overhaul plot_dff aesthetics and add full-baseline mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+notebooks/
 
 # IPython
 profile_default/

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -261,29 +261,29 @@ def plot_dff(
     fig, ax = plt.subplots(n_rows, 1, figsize=(12, n_rows * 1.2), sharex=True)
 
     # panel 0: raw signal + baseline(s)
-    ax[0].plot(t, F, label="$F$", lw=0.5)
+    ax[0].plot(t, F, label="F", lw=0.5)
     if has_fluctuations:
-        ax[0].plot(t, F0trend, label="$F_{0,trend}$", lw=0.5)
-    ax[0].plot(t, F0, c="#F0E442", label="$F_0$", lw=0.5)
-    ax[0].set_ylabel("$F$ [a.u.]")
+        ax[0].plot(t, F0trend, c="C3", label=r"$\mathrm{F}_{0,\mathrm{trend}}$")
+    ax[0].plot(t, F0, c="#F0E442", label="F₀")
+    ax[0].set_ylabel("F [a.u.]")
     ax[0].legend(loc=1)
 
     # panel 1: fluctuations (full-baseline mode only)
     if has_fluctuations:
-        ax[1].plot(t, F - F0trend, c="C1", label="$F-F_{0,trend}$", lw=0.5)
+        ax[1].plot(t, F - F0trend, c="C4", label=r"$\mathrm{F} - \mathrm{F}_{0,\mathrm{trend}}$", lw=0.5)
         ax[1].axhline(0, ls="--", c="k")
-        ax[1].plot(t, F0 - F0trend, c="C2", label="$F_{0,fluct}$", lw=0.5)
-        ax[1].set_ylabel("$\\Delta F$ [a.u.]")
+        ax[1].plot(t, F0 - F0trend, c="C5", label=r"$\mathrm{F}_{0,\mathrm{fluct}}$")
+        ax[1].set_ylabel("ΔF [a.u.]")
         ax[1].legend(loc=1)
 
     # dF/F panels: one per baseline when has_fluctuations, otherwise just F0
     dff_traces = (
         [
-            (F / F0trend - 1, "C1", "$\\frac{\\Delta F}{F_{0,trend}}$"),
-            (F / F0 - 1, "C2", "$\\frac{\\Delta F}{F_0}$"),
+            (F / F0trend - 1, "C1", r"$\Delta\mathrm{F}/\mathrm{F}_{0,\mathrm{trend}}$"),
+            (F / F0 - 1, "C2", "ΔF/F₀"),
         ]
         if has_fluctuations
-        else [(F / F0 - 1, "C2", "$\\frac{\\Delta F}{F_0}$")]
+        else [(F / F0 - 1, "C2", "ΔF/F₀")]
     )
     # row layout per trace: [spacer, dff_panel] when insets, else [dff_panel]
     first_dff_row = 2 if has_fluctuations else 1
@@ -304,7 +304,7 @@ def plot_dff(
         dff_row = spacer_row + (1 if show_insets else 0)
         ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5)
         ax[dff_row].axhline(0, ls="--", c="k")
-        ax[dff_row].set_ylabel(r"$\Delta$F/F [%]", y=1 if show_insets else 0.5)
+        ax[dff_row].set_ylabel("ΔF/F [%]", y=1 if show_insets else 0.5)
         ax[dff_row].legend(loc=1)
         if show_insets:
             add_zoom_insets(

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -328,7 +328,7 @@ def plot_dff(
     for i, (dff_trace, color, label) in enumerate(dff_traces):
         spacer_row = first_dff_row + i * (2 if show_insets else 1)
         dff_row = spacer_row + (1 if show_insets else 0)
-        ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5)
+        ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5, zorder=-1)
         ax[dff_row].axhline(0, ls="--", c="k")
         ax[dff_row].set_ylabel(
             r"$\Delta\mathrm{F}/\mathrm{F}$ [%]", y=1 if show_insets else 0.5

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -266,7 +266,7 @@ def plot_dff(
         ax[0].plot(t, F0trend, c="C3", label=r"$\mathrm{F}_{0,\mathrm{trend}}$")
     ax[0].plot(t, F0, c="#F0E442", label="F₀")
     ax[0].set_ylabel("F [a.u.]")
-    ax[0].legend(loc=1)
+    ax[0].legend(loc=1, frameon=False)
 
     # panel 1: fluctuations (full-baseline mode only)
     if has_fluctuations:
@@ -274,7 +274,7 @@ def plot_dff(
         ax[1].axhline(0, ls="--", c="k")
         ax[1].plot(t, F0 - F0trend, c="C5", label=r"$\mathrm{F}_{0,\mathrm{fluct}}$")
         ax[1].set_ylabel("ΔF [a.u.]")
-        ax[1].legend(loc=1)
+        ax[1].legend(loc=1, frameon=False)
 
     # dF/F panels: one per baseline when has_fluctuations, otherwise just F0
     dff_traces = (
@@ -305,7 +305,7 @@ def plot_dff(
         ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5)
         ax[dff_row].axhline(0, ls="--", c="k")
         ax[dff_row].set_ylabel("ΔF/F [%]", y=1 if show_insets else 0.5)
-        ax[dff_row].legend(loc=1)
+        ax[dff_row].legend(loc=1, frameon=False)
         if show_insets:
             add_zoom_insets(
                 ax[spacer_row], ax[dff_row], t, dff_trace, zoom_windows, color
@@ -315,7 +315,5 @@ def plot_dff(
     ax[-1].set_xlabel("Time [s]")
     if roi_id is not None:
         ax[0].set_title(f"cell_roi_id: {int(roi_id)}")
-    plt.subplots_adjust(
-        hspace=0.1, top=0.935, bottom=0.13, left=0.06, right=0.995
-    )
+    plt.subplots_adjust(hspace=0.1, top=0.97)
     return fig

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -258,7 +258,7 @@ def plot_dff(
         if has_fluctuations
         else (3 if show_insets else 2)
     )
-    fig, ax = plt.subplots(n_rows, 1, figsize=(12, n_rows * 1.2), sharex=True)
+    fig, ax = plt.subplots(n_rows, 1, figsize=(12, n_rows * 1.1), sharex=True)
 
     # panel 0: raw signal + baseline(s)
     ax[0].plot(t, F, label="F", lw=0.5)
@@ -328,7 +328,9 @@ def plot_dff(
     for i, (dff_trace, color, label) in enumerate(dff_traces):
         spacer_row = first_dff_row + i * (2 if show_insets else 1)
         dff_row = spacer_row + (1 if show_insets else 0)
-        ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5, zorder=-1)
+        ax[dff_row].plot(
+            t, 100 * dff_trace, c=color, label=label, lw=0.5, zorder=-1
+        )
         ax[dff_row].axhline(0, ls="--", c="k")
         ax[dff_row].set_ylabel(
             r"$\Delta\mathrm{F}/\mathrm{F}$ [%]", y=1 if show_insets else 0.5
@@ -349,5 +351,5 @@ def plot_dff(
     ax[-1].set_xlabel("Time [s]")
     if roi_id is not None:
         ax[0].set_title(f"cell_roi_id: {int(roi_id)}")
-    plt.subplots_adjust(hspace=0.1, top=0.97)
+    plt.subplots_adjust(hspace=0.1, top=0.97, left=0.06, right=0.995)
     return fig

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -263,27 +263,53 @@ def plot_dff(
     # panel 0: raw signal + baseline(s)
     ax[0].plot(t, F, label="F", lw=0.5)
     if has_fluctuations:
-        ax[0].plot(t, F0trend, c="C3", label=r"$\mathrm{F}_{0,\mathrm{trend}}$")
-    ax[0].plot(t, F0, c="#F0E442", label="F₀")
+        ax[0].plot(
+            t, F0trend, c="C3", label=r"$\mathrm{F}_{0,\mathrm{trend}}$"
+        )
+    ax[0].plot(t, F0, c="#F0E442", label=r"$\mathrm{F}_0$")
     ax[0].set_ylabel("F [a.u.]")
-    ax[0].legend(loc='upper right', ncol=3 if has_fluctuations else 2, borderpad=0.05, borderaxespad=0.3).get_frame().set_linewidth(0.0)
+    legend = ax[0].legend(
+        loc="upper right",
+        ncol=3 if has_fluctuations else 2,
+        borderpad=0.05,
+        borderaxespad=0.3,
+    )
+    legend.get_frame().set_linewidth(0.0)
 
     # panel 1: fluctuations (full-baseline mode only)
     if has_fluctuations:
-        ax[1].plot(t, F - F0trend, c="C4", label=r"$\mathrm{F} - \mathrm{F}_{0,\mathrm{trend}}$", lw=0.5)
+        ax[1].plot(
+            t,
+            F - F0trend,
+            c="C4",
+            label=r"$\mathrm{F} - \mathrm{F}_{0,\mathrm{trend}}$",
+            lw=0.5,
+        )
         ax[1].axhline(0, ls="--", c="k")
-        ax[1].plot(t, F0 - F0trend, c="C5", label=r"$\mathrm{F}_{0,\mathrm{fluct}}$")
-        ax[1].set_ylabel("ΔF [a.u.]")
-        ax[1].legend(loc='upper right', ncol=2, borderpad=0.05, borderaxespad=0.3).get_frame().set_linewidth(0.0)
+        ax[1].plot(
+            t, F0 - F0trend, c="C5", label=r"$\mathrm{F}_{0,\mathrm{fluct}}$"
+        )
+        ax[1].set_ylabel(r"$\Delta\mathrm{F}$ [a.u.]")
+        legend = ax[1].legend(
+            loc="upper right",
+            ncol=2,
+            borderpad=0.05,
+            borderaxespad=0.3,
+        )
+        legend.get_frame().set_linewidth(0.0)
 
     # dF/F panels: one per baseline when has_fluctuations, otherwise just F0
     dff_traces = (
         [
-            (F / F0trend - 1, "C1", r"$\Delta\mathrm{F}/\mathrm{F}_{0,\mathrm{trend}}$"),
-            (F / F0 - 1, "C2", "ΔF/F₀"),
+            (
+                F / F0trend - 1,
+                "C1",
+                r"$\Delta\mathrm{F}/\mathrm{F}_{0,\mathrm{trend}}$",
+            ),
+            (F / F0 - 1, "C2", r"$\Delta\mathrm{F}/\mathrm{F}_0$"),
         ]
         if has_fluctuations
-        else [(F / F0 - 1, "C2", "ΔF/F₀")]
+        else [(F / F0 - 1, "C2", r"$\Delta\mathrm{F}/\mathrm{F}_0$")]
     )
     # row layout per trace: [spacer, dff_panel] when insets, else [dff_panel]
     first_dff_row = 2 if has_fluctuations else 1
@@ -304,8 +330,16 @@ def plot_dff(
         dff_row = spacer_row + (1 if show_insets else 0)
         ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5)
         ax[dff_row].axhline(0, ls="--", c="k")
-        ax[dff_row].set_ylabel("ΔF/F [%]", y=1 if show_insets else 0.5)
-        ax[dff_row].legend(loc='upper right', ncol=1, borderpad=0.05, borderaxespad=0.3).get_frame().set_linewidth(0.0)
+        ax[dff_row].set_ylabel(
+            r"$\Delta\mathrm{F}/\mathrm{F}$ [%]", y=1 if show_insets else 0.5
+        )
+        legend = ax[dff_row].legend(
+            loc="upper right",
+            ncol=1,
+            borderpad=0.05,
+            borderaxespad=0.3,
+        )
+        legend.get_frame().set_linewidth(0.0)
         if show_insets:
             add_zoom_insets(
                 ax[spacer_row], ax[dff_row], t, dff_trace, zoom_windows, color

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -261,18 +261,18 @@ def plot_dff(
     fig, ax = plt.subplots(n_rows, 1, figsize=(12, n_rows * 1.2), sharex=True)
 
     # panel 0: raw signal + baseline(s)
-    ax[0].plot(t, F, label="$F$")
+    ax[0].plot(t, F, label="$F$", lw=0.5)
     if has_fluctuations:
-        ax[0].plot(t, F0trend, label="$F_{0,trend}$")
-    ax[0].plot(t, F0, c="#F0E442", label="$F_0$")
+        ax[0].plot(t, F0trend, label="$F_{0,trend}$", lw=0.5)
+    ax[0].plot(t, F0, c="#F0E442", label="$F_0$", lw=0.5)
     ax[0].set_ylabel("$F$ [a.u.]")
     ax[0].legend(loc=1)
 
     # panel 1: fluctuations (full-baseline mode only)
     if has_fluctuations:
-        ax[1].plot(t, F - F0trend, c="C1", label="$F-F_{0,trend}$")
+        ax[1].plot(t, F - F0trend, c="C1", label="$F-F_{0,trend}$", lw=0.5)
         ax[1].axhline(0, ls="--", c="k")
-        ax[1].plot(t, F0 - F0trend, c="C2", label="$F_{0,fluct}$")
+        ax[1].plot(t, F0 - F0trend, c="C2", label="$F_{0,fluct}$", lw=0.5)
         ax[1].set_ylabel("$\\Delta F$ [a.u.]")
         ax[1].legend(loc=1)
 
@@ -283,7 +283,7 @@ def plot_dff(
             (F / F0 - 1, "C2", "$\\frac{\\Delta F}{F_0}$"),
         ]
         if has_fluctuations
-        else [(F / F0 - 1, "C1", "$\\frac{\\Delta F}{F_0}$")]
+        else [(F / F0 - 1, "C2", "$\\frac{\\Delta F}{F_0}$")]
     )
     # row layout per trace: [spacer, dff_panel] when insets, else [dff_panel]
     first_dff_row = 2 if has_fluctuations else 1
@@ -302,9 +302,9 @@ def plot_dff(
     for i, (dff_trace, color, label) in enumerate(dff_traces):
         spacer_row = first_dff_row + i * (2 if show_insets else 1)
         dff_row = spacer_row + (1 if show_insets else 0)
-        ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label)
+        ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5)
         ax[dff_row].axhline(0, ls="--", c="k")
-        ax[dff_row].set_ylabel(r"$\Delta$F/F [%]")
+        ax[dff_row].set_ylabel(r"$\Delta$F/F [%]", y=1 if show_insets else 0.5)
         ax[dff_row].legend(loc=1)
         if show_insets:
             add_zoom_insets(

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -266,7 +266,7 @@ def plot_dff(
         ax[0].plot(t, F0trend, c="C3", label=r"$\mathrm{F}_{0,\mathrm{trend}}$")
     ax[0].plot(t, F0, c="#F0E442", label="F₀")
     ax[0].set_ylabel("F [a.u.]")
-    ax[0].legend(loc=1, frameon=False)
+    ax[0].legend(loc='upper right', ncol=3 if has_fluctuations else 2, borderpad=0.05, borderaxespad=0.3).get_frame().set_linewidth(0.0)
 
     # panel 1: fluctuations (full-baseline mode only)
     if has_fluctuations:
@@ -274,7 +274,7 @@ def plot_dff(
         ax[1].axhline(0, ls="--", c="k")
         ax[1].plot(t, F0 - F0trend, c="C5", label=r"$\mathrm{F}_{0,\mathrm{fluct}}$")
         ax[1].set_ylabel("ΔF [a.u.]")
-        ax[1].legend(loc=1, frameon=False)
+        ax[1].legend(loc='upper right', ncol=2, borderpad=0.05, borderaxespad=0.3).get_frame().set_linewidth(0.0)
 
     # dF/F panels: one per baseline when has_fluctuations, otherwise just F0
     dff_traces = (
@@ -305,7 +305,7 @@ def plot_dff(
         ax[dff_row].plot(t, 100 * dff_trace, c=color, label=label, lw=0.5)
         ax[dff_row].axhline(0, ls="--", c="k")
         ax[dff_row].set_ylabel("ΔF/F [%]", y=1 if show_insets else 0.5)
-        ax[dff_row].legend(loc=1, frameon=False)
+        ax[dff_row].legend(loc='upper right', ncol=1, borderpad=0.05, borderaxespad=0.3).get_frame().set_linewidth(0.0)
         if show_insets:
             add_zoom_insets(
                 ax[spacer_row], ax[dff_row], t, dff_trace, zoom_windows, color

--- a/src/aind_ophys_utils/dff.py
+++ b/src/aind_ophys_utils/dff.py
@@ -258,32 +258,32 @@ def plot_dff(
         if has_fluctuations
         else (3 if show_insets else 2)
     )
-    fig, ax = plt.subplots(n_rows, 1, figsize=(15, n_rows * 1.2), sharex=True)
+    fig, ax = plt.subplots(n_rows, 1, figsize=(12, n_rows * 1.2), sharex=True)
 
     # panel 0: raw signal + baseline(s)
     ax[0].plot(t, F, label="$F$")
     if has_fluctuations:
-        ax[0].plot(t, F0trend, label="$F0_{trend}$")
-    ax[0].plot(t, F0, label="$F0$")
+        ax[0].plot(t, F0trend, label="$F_{0,trend}$")
+    ax[0].plot(t, F0, c="#F0E442", label="$F_0$")
     ax[0].set_ylabel("$F$ [a.u.]")
     ax[0].legend(loc=1)
 
     # panel 1: fluctuations (full-baseline mode only)
     if has_fluctuations:
-        ax[1].plot(t, F - F0trend, c="C1", label="$F-F0_{trend}$")
+        ax[1].plot(t, F - F0trend, c="C1", label="$F-F_{0,trend}$")
         ax[1].axhline(0, ls="--", c="k")
-        ax[1].plot(t, F0 - F0trend, c="C2", label="$F0_{fluctuations}$")
+        ax[1].plot(t, F0 - F0trend, c="C2", label="$F_{0,fluct}$")
         ax[1].set_ylabel("$\\Delta F$ [a.u.]")
         ax[1].legend(loc=1)
 
     # dF/F panels: one per baseline when has_fluctuations, otherwise just F0
     dff_traces = (
         [
-            (F / F0trend - 1, "C1", "$\\frac{\\Delta F_{trend}}{F0_{trend}}$"),
-            (F / F0 - 1, "C2", "$\\frac{\\Delta F}{F}$"),
+            (F / F0trend - 1, "C1", "$\\frac{\\Delta F}{F_{0,trend}}$"),
+            (F / F0 - 1, "C2", "$\\frac{\\Delta F}{F_0}$"),
         ]
         if has_fluctuations
-        else [(F / F0 - 1, "C1", "$\\frac{\\Delta F}{F0}$")]
+        else [(F / F0 - 1, "C1", "$\\frac{\\Delta F}{F_0}$")]
     )
     # row layout per trace: [spacer, dff_panel] when insets, else [dff_panel]
     first_dff_row = 2 if has_fluctuations else 1

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -152,8 +152,10 @@ def fill_nan(input: np.ndarray) -> np.ndarray:
         Copied input array with filled nan values.
     """
     nan_mask = np.isnan(input)
-    nan_indices = np.where(nan_mask)[0]
     no_nan_indices = np.where(~nan_mask)[0]
+    if no_nan_indices.size == 0:
+        return input.copy()
+    nan_indices = np.where(nan_mask)[0]
     interpolated_values = np.interp(
         nan_indices, no_nan_indices, input[no_nan_indices]
     )
@@ -475,7 +477,14 @@ def noise_std(  # noqa: C901
                     dims = x.shape[:-1]
                     return np.reshape(
                         [
-                            noise_std(row, method="fft", skipna=True)
+                            noise_std(
+                                row,
+                                method="fft",
+                                max_num_samples=max_num_samples,
+                                noise_range=noise_range,
+                                device=device,
+                                skipna=True,
+                            )
                             for row in x.reshape(-1, T)
                         ],
                         dims,

--- a/tests/test_signal_utils.py
+++ b/tests/test_signal_utils.py
@@ -128,6 +128,14 @@ def test_fill_nan():
     assert not np.isnan(output).any()
 
 
+def test_fill_nan_all_nan():
+    """fill_nan returns a copy unchanged when all values are NaN."""
+    arr = np.full(5, np.nan)
+    output = fill_nan(arr)
+    assert np.all(np.isnan(output))
+    assert output is not arr
+
+
 @pytest.mark.parametrize(
     "x, expected, axis",
     [


### PR DESCRIPTION
## Summary

- **figsize**: `(15, n_rows * 1.2)` → `(12, n_rows * 1.1)` to match capsule output dimensions
- **Colors**: distinct color per quantity — C3 F₀,trend, C4 F−F₀,trend, C5 F₀,fluct, C1 ΔF/F₀,trend, C2 ΔF/F₀; F₀ baseline in `#F0E442`
- **Labels**: all switched to `\mathrm` mathtext for consistent rendering across backends
- **Legend**: frameless border (`linewidth=0`), `ncol` = number of entries per panel, `borderaxespad=0.3`
- **Layout**: `subplots_adjust(hspace=0.1, top=0.97, left=0.06, right=0.995)` to preserve width on save
- **dF/F traces**: `zorder=-1` so inset markers render on top
- **y-label**: simplified to `ΔF/F [%]` for all dF/F panels; position `y=1` when insets shown
- **Full-baseline mode** (`F0trend` parameter): new 4-panel layout showing trend, fluctuations, and both dF/F traces with per-panel colors
- **Bug fixes** (flagged in Copilot review of PR #72):
  - `fill_nan` now returns a copy unchanged on all-NaN input instead of raising `ValueError`
  - `noise_std(method='fft', skipna=True)` 2D recursion now correctly forwards `max_num_samples`, `noise_range`, and `device`
- **`.gitignore`**: added `notebooks/` to keep local development notebooks out of version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)