### PR TITLE
fix: address Copilot review comments on PR #72

### DIFF
--- a/src/aind_ophys_utils/motion_border_utils.py
+++ b/src/aind_ophys_utils/motion_border_utils.py
@@ -45,7 +45,7 @@ def get_max_correction_values(
     # directions
     max_shift = abs(max_shift)
 
-    # filter based out analomies based on maximum_shift
+    # filter out anomalies based on maximum_shift
     x_no_outliers = x_series[(x_series >= -max_shift) & (x_series <= max_shift)]
     y_no_outliers = y_series[(y_series >= -max_shift) & (y_series <= max_shift)]
     # calculate max border shifts
@@ -54,17 +54,17 @@ def get_max_correction_values(
     down_shift = -1 * y_no_outliers.min()
     up_shift = y_no_outliers.max()
 
-    max_shift = MaxFrameShift(left=left_shift, right=right_shift, up=up_shift, down=down_shift)
+    frame_shift = MaxFrameShift(left=left_shift, right=right_shift, up=up_shift, down=down_shift)
 
     # check if all exist
-    if np.any(np.isnan(np.array(max_shift))):
+    if np.any(np.isnan(np.array(frame_shift))):
         raise ValueError(
             "One or more motion correction shifts "
             "was found to be Nan, max shift found: "
-            f"{max_shift}, with max_shift {max_shift}"
+            f"{frame_shift}, with max_shift {max_shift}"
         )
 
-    return max_shift
+    return frame_shift
 
 
 def get_max_correction_from_df(input_df: pd.DataFrame, max_shift: float = 30.0) -> MaxFrameShift:

--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -51,6 +51,8 @@ def percentile_filter(
         fn = np.nanpercentile if skipna else np.percentile
         return (fn(input, percentile) * np.ones_like(input)).astype(dtype)
     if skipna:
+        if size == 1:
+            return input.copy().astype(dtype)
         padded = np.concatenate((input[: size // 2][::-1], input, input[: -size // 2 - 1 : -1]))
         return (
             pd.Series(padded)
@@ -89,7 +91,7 @@ def median_filter(
     return percentile_filter(input, 50, size, dtype, skipna=skipna)
 
 
-def nanmedian_filter(input: np.ndarray, size: int, dtype: type | None = None) -> np.array:
+def nanmedian_filter(input: np.ndarray, size: int, dtype: type | None = None) -> np.ndarray:
     """1D median filtering with nan values
 
     .. deprecated::

--- a/src/aind_ophys_utils/summary_images.py
+++ b/src/aind_ophys_utils/summary_images.py
@@ -237,7 +237,7 @@ def pnr_image(
     """
     if downscale > 1:
         mov = downsample_array(mov, factors=downscale, skipna=skipna)
-    noise = noise_std(mov, method, dim=0, device=device, skipna=skipna)
+    noise = noise_std(mov, method, axis=0, device=device, skipna=skipna)
     if skipna:
         return (np.nanmax(mov, 0) - np.nanmedian(mov, 0)) / noise
     return (np.max(mov, 0) - np.median(mov, 0)) / noise

--- a/src/aind_ophys_utils/summary_images.py
+++ b/src/aind_ophys_utils/summary_images.py
@@ -80,7 +80,7 @@ def local_correlations(
     rho[:, 1:] += rho_w
 
     if eight_neighbours:
-        rho_d1 = mean(torch.multiply(w_mov[:, 1:, :-1], w_mov[:, :-1, 1:]), axis=0)
+        rho_d1 = mean(torch.multiply(w_mov[:, 1:, :-1], w_mov[:, :-1, 1:]), dim=0)
         rho_d2 = mean(
             torch.multiply(
                 w_mov[:, :-1, :-1],
@@ -90,7 +90,7 @@ def local_correlations(
                     1:,
                 ],
             ),
-            axis=0,
+            dim=0,
         )
 
         rho[1:, :-1] += rho_d1
@@ -237,7 +237,7 @@ def pnr_image(
     """
     if downscale > 1:
         mov = downsample_array(mov, factors=downscale, skipna=skipna)
-    noise = noise_std(mov, method, axis=0, device=device, skipna=skipna)
+    noise = noise_std(mov, method, dim=0, device=device, skipna=skipna)
     if skipna:
         return (np.nanmax(mov, 0) - np.nanmedian(mov, 0)) / noise
     return (np.max(mov, 0) - np.median(mov, 0)) / noise

--- a/tests/test_signal_utils.py
+++ b/tests/test_signal_utils.py
@@ -112,6 +112,8 @@ def test_nanmedian_filter(input, size, expected):
             3,
             np.array([1.0, 1.0, np.nan, np.nan, 5.0, 5.0]),
         ),
+        # size == 1: returns copy of input unchanged
+        (np.array([1.0, np.nan, 3.0]), 1, np.array([1.0, np.nan, 3.0])),
     ],
 )
 def test_median_filter_skipna(array, size, expected):
@@ -226,6 +228,15 @@ def test_noise_std_skipna_2d(method):
     x_nan = x.copy()
     x_nan[:, 3000:4000] = np.nan
     result = noise_std(x_nan, method=method, skipna=True)
+    assert result.shape == (5,)
+    assert_allclose(result, np.ones(5), rtol=0.2, atol=0.2)
+
+
+def test_noise_std_axis():
+    """noise_std with axis=0 on 2D input triggers np.moveaxis."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((10000, 5))
+    result = noise_std(x, axis=0)
     assert result.shape == (5,)
     assert_allclose(result, np.ones(5), rtol=0.2, atol=0.2)
 

--- a/tests/test_video_utils.py
+++ b/tests/test_video_utils.py
@@ -101,6 +101,6 @@ def test_encode_video(raw_video_fixture, tmp_path):
     fps = raw_video_fixture["fps"]
     expected_video = raw_video_fixture["raw_video"]
 
-    (vu.encode_video(video=expected_video, output_path=output_path.as_posix(), fps=fps),)
+    vu.encode_video(video=expected_video, output_path=output_path.as_posix(), fps=fps)
 
     compare_videos(output_path, expected_video)


### PR DESCRIPTION
## Summary

Fixes flagged in the Copilot review of PR #72:

- **`percentile_filter` skipna size==1**: `[size // 2 : -size // 2]` became `[0:0]` returning an empty array — added explicit fast-path returning a copy
- **`nanmedian_filter` return type**: `-> np.array` (a constructor) corrected to `-> np.ndarray`
- **`summary_images` `axis=` → `dim=`**: `torch.mean`/`torch.nanmean` use `dim=`, not `axis=`; affected the eight-neighbours correlation branch
- **`motion_border_utils` variable reuse**: renamed result to `frame_shift` to separate it from the numeric `max_shift` threshold; error message now shows both correctly
- **`motion_border_utils` spelling**: `analomies` → `anomalies`
- **`test_video_utils` 1-tuple**: removed spurious trailing comma wrapping `encode_video` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)