### PR TITLE
Raise a clear error for non-positive size in percentile_filter

### DIFF
--- a/src/aind_ophys_utils/signal_utils.py
+++ b/src/aind_ophys_utils/signal_utils.py
@@ -45,6 +45,8 @@ def percentile_filter(
     filtered_trace: ndarray
         Filtered array. Has the same shape as `input`.
     """
+    if size < 1:
+        raise ValueError(f"size must be a positive integer, got {size}")
     if dtype is None:
         dtype = input.dtype
     if size > len(input):

--- a/tests/test_signal_utils.py
+++ b/tests/test_signal_utils.py
@@ -122,6 +122,14 @@ def test_median_filter_skipna(array, size, expected):
     np.testing.assert_allclose(output, expected, equal_nan=True)
 
 
+@pytest.mark.parametrize("size", [0, -1, -5])
+def test_percentile_filter_invalid_size(size):
+    """A non-positive size raises a clear error instead of silently
+    misbehaving (e.g. from a degenerate filter length computed upstream)."""
+    with pytest.raises(ValueError, match="size must be a positive integer"):
+        percentile_filter(np.arange(10.0), 50, size)
+
+
 def test_fill_nan():
     """Test fill_nan interpolates NaN values"""
     arr = np.array([1.0, np.nan, np.nan, 4.0])


### PR DESCRIPTION
## Summary

Found while diagnosing a `ValueError: operands could not be broadcast together with shapes (788,) (0,)` crash downstream in `_dff_single_trace`, coming from a fallback path in `aind-ophys-dff-library`'s `triexp_dff.py` that computes `fs = 1.0 / float(np.median(np.diff(t_rel)))` — for an ROI where `t_rel` is degenerate (non-monotonic/duplicate timestamps), this can produce a negative `fs`, which flows into `long_filter_length = int(long_window * fs / 2) * 2 + 1` and comes out negative.

`percentile_filter`'s `skipna=True` branch already guards `size > len(input)`, but not `size < 1`. A negative `size` falls through into the padding/slicing logic (`input[: size // 2]`, `[size // 2 : -size // 2]`), where the sign-flip in `size // 2` vs. `-size // 2` can put the final slice's start past its end, silently returning a wrong-shaped (in this case empty) array instead of raising anything — so the real failure surfaces two calls downstream, as a confusing broadcast-shape error, rather than at the actual bad parameter.

This adds an explicit `size < 1` check that raises immediately with a clear message.

## Testing

- Added `test_percentile_filter_invalid_size` (parametrized over `0`, `-1`, `-5`).
- Full suite: 430 passed, 100% coverage maintained.
- `ruff format --check` / `ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)